### PR TITLE
Basic Namco GunCon emulation

### DIFF
--- a/PSX.sv
+++ b/PSX.sv
@@ -252,8 +252,8 @@ parameter CONF_STR = {
 	"-;",
 	"o78,System Type,NTSC-U,NTSC-J,PAL;",
    "-;",
-	"oDF,Pad1,Digital,Analog,Mouse,Off;",
-	"oGI,Pad2,Digital,Analog,Mouse,Off;",
+	"oDF,Pad1,Digital,Analog,Mouse,Off,GunCon;",
+	"oGI,Pad2,Digital,Analog,Mouse,Off,GunCon;",
    "-;",
 	"OG,Fastboot,Off,On;",
 	"d1oC,SPU RAM select,DDR3,SDRAM2;",
@@ -584,14 +584,17 @@ defparam savestate_ui.INFO_TIMEOUT_BITS = 27;
 // 000 -> analog
 // 000 -> mouse
 // 011 -> off
-// 100..111 -> reserved
+// 100 -> Namco GunCon lightgun
+// 101..111 -> reserved
 
 wire PadPortEnable1 = (status[47:45] != 3'b011);
 wire PadPortAnalog1 = (status[47:45] == 3'b001);
 wire PadPortMouse1  = (status[47:45] == 3'b010);
+wire PadPortGunCon1 = (status[47:45] == 3'b100);
 wire PadPortEnable2 = (status[50:48] != 3'b011);
 wire PadPortAnalog2 = (status[50:48] == 3'b001);
 wire PadPortMouse2  = (status[50:48] == 3'b010);
+wire PadPortGunCon2 = (status[50:48] == 3'b100);
 
 ////////////////////////////  SYSTEM  ///////////////////////////////////
 
@@ -708,9 +711,11 @@ psx
    .PadPortEnable1 (PadPortEnable1),
    .PadPortAnalog1 (PadPortAnalog1),
    .PadPortMouse1  (PadPortMouse1 ),
+   .PadPortGunCon1 (PadPortGunCon1),
    .PadPortEnable2 (PadPortEnable2),
    .PadPortAnalog2 (PadPortAnalog2),
    .PadPortMouse2  (PadPortMouse2 ),
+   .PadPortGunCon2 (PadPortGunCon2),
    .KeyTriangle({joy2[4], joy[4] }),    
    .KeyCircle  ({joy2[5] ,joy[5] }),       
    .KeyCross   ({joy2[6] ,joy[6] }),       

--- a/rtl/joypad.vhd
+++ b/rtl/joypad.vhd
@@ -16,9 +16,11 @@ entity joypad is
       PadPortEnable1       : in  std_logic;
       PadPortAnalog1       : in  std_logic;
       PadPortMouse1        : in  std_logic;
+      PadPortGunCon1       : in  std_logic;
       PadPortEnable2       : in  std_logic;
       PadPortAnalog2       : in  std_logic;
       PadPortMouse2        : in  std_logic;
+      PadPortGunCon2       : in  std_logic;
       
       memcard1_available   : in  std_logic;
       memcard2_available   : in  std_logic;
@@ -362,6 +364,7 @@ begin
       PortEnabled          => PadPortEnable1,
       analogPad            => PadPortAnalog1,
       isMouse              => PadPortMouse1,
+      isGunCon             => PadPortGunCon1,
 
       selected             => selectedPad1,
       actionNext           => actionNextPad,
@@ -414,6 +417,7 @@ begin
       PortEnabled          => PadPortEnable2,
       analogPad            => PadPortAnalog2,
       isMouse              => PadPortMouse2,
+      isGunCon             => PadPortGunCon2,
 
       selected             => selectedPad2,
       actionNext           => actionNextPad,

--- a/rtl/psx_mister.vhd
+++ b/rtl/psx_mister.vhd
@@ -119,9 +119,11 @@ entity psx_mister is
       PadPortEnable1        : in  std_logic;
       PadPortAnalog1        : in  std_logic;
       PadPortMouse1         : in  std_logic;
+      PadPortGunCon1        : in  std_logic;
       PadPortEnable2        : in  std_logic;
       PadPortAnalog2        : in  std_logic;
       PadPortMouse2         : in  std_logic;
+      PadPortGunCon2        : in  std_logic;
       KeyTriangle           : in  std_logic_vector(1 downto 0); 
       KeyCircle             : in  std_logic_vector(1 downto 0); 
       KeyCross              : in  std_logic_vector(1 downto 0); 
@@ -294,9 +296,11 @@ begin
       PadPortEnable1        => PadPortEnable1,
       PadPortAnalog1        => PadPortAnalog1,
       PadPortMouse1         => PadPortMouse1,
+      PadPortGunCon1        => PadPortGunCon1,
       PadPortEnable2        => PadPortEnable2,
       PadPortAnalog2        => PadPortAnalog2,
       PadPortMouse2         => PadPortMouse2, 
+      PadPortGunCon2        => PadPortGunCon2,
       KeyTriangle           => KeyTriangle,           
       KeyCircle             => KeyCircle,           
       KeyCross              => KeyCross,           

--- a/rtl/psx_top.vhd
+++ b/rtl/psx_top.vhd
@@ -123,9 +123,11 @@ entity psx_top is
       PadPortEnable1        : in  std_logic;
       PadPortAnalog1        : in  std_logic;
       PadPortMouse1         : in  std_logic;
+      PadPortGunCon1        : in  std_logic;
       PadPortEnable2        : in  std_logic;
       PadPortAnalog2        : in  std_logic;
       PadPortMouse2         : in  std_logic;
+      PadPortGunCon2        : in  std_logic;
       KeyTriangle           : in  std_logic_vector(1 downto 0); 
       KeyCircle             : in  std_logic_vector(1 downto 0); 
       KeyCross              : in  std_logic_vector(1 downto 0); 
@@ -858,9 +860,11 @@ begin
       PadPortEnable1       => PadPortEnable1,
       PadPortAnalog1       => PadPortAnalog1,
       PadPortMouse1        => PadPortMouse1,
+      PadPortGunCon1       => PadPortGunCon1,
       PadPortEnable2       => PadPortEnable2,
       PadPortAnalog2       => PadPortAnalog2,
       PadPortMouse2        => PadPortMouse2, 
+      PadPortGunCon2       => PadPortGunCon2,
       
       memcard1_available   => memcard1_available,
       memcard2_available   => memcard2_available,


### PR DESCRIPTION
This PR adds bare-bones support for interpreting an analog joystick (or a MiSTer lightgun) as the Namco GunCon. To enable for a pad, set it to "GunCon" in the OSD.

The left stick is interpreted as the gun coordinates. Circle is used as the Trigger, Start is used as the "A" (left-side) button, and Cross is used as the "B" (right-side) button. A different button mapping may be more appropriate.

The original GunCon delivers its X coordinate as a number of 8 MHz clocks since the last HSYNC, and its Y coordinate as a number of scanlines since the last VSYNC. This is not a clean multiple of the +/-128 analog joystick range. For economy's sake, instead of doing an integer multiply to map precisely to the screen, the Y value is left un-scaled, and the X value is doubled. Lightgun users wanting an exact map to their screen should be able to compensate for this using the MiSTer's lightgun calibration settings.

This does not add an on-screen cursor, nor does it add support for interpreting a mouse as the GunCon. This also does not add support for the Konami Justifier.