### PR TITLE
Lightgun cursors + GunCon position calculation

### DIFF
--- a/rtl/gpu.vhd
+++ b/rtl/gpu.vhd
@@ -24,13 +24,13 @@ entity gpu is
       noTexture            : in  std_logic;
       debugmodeOn          : in  std_logic;
 
-      gun1CrosshairOn      : in  std_logic;
-      gun1X                : in  integer range 0 to 255;
-      gun1Y                : in  integer range 0 to 255;
+      Gun1CrosshairOn      : in  std_logic;
+      Gun1X                : in  unsigned(7 downto 0);
+      Gun1Y                : in  unsigned(7 downto 0);
 
-      gun2CrosshairOn      : in  std_logic;
-      gun2X                : in  integer range 0 to 255;
-      gun2Y                : in  integer range 0 to 255;
+      Gun2CrosshairOn      : in  std_logic;
+      Gun2X                : in  unsigned(7 downto 0);
+      Gun2Y                : in  unsigned(7 downto 0);
       
       cdSlow               : in  std_logic;
       
@@ -1684,13 +1684,13 @@ begin
       fpscountOn              => fpscountOn,
       fpscountBCD             => fpscountBCD,
 
-      gun1CrosshairOn         => gun1CrosshairOn,
-      gun1X                   => gun1X,
-      gun1Y                   => gun1Y,
+      Gun1CrosshairOn         => Gun1CrosshairOn,
+      Gun1X                   => Gun1X,
+      Gun1Y                   => Gun1Y,
 
-      gun2CrosshairOn         => gun2CrosshairOn,
-      gun2X                   => gun2X,
-      gun2Y                   => gun2Y,
+      Gun2CrosshairOn         => Gun2CrosshairOn,
+      Gun2X                   => Gun2X,
+      Gun2Y                   => Gun2Y,
       
       debug_lateSamples       => debug_lateSamples,
       debug_lateTicks         => debug_lateTicks, 

--- a/rtl/gpu.vhd
+++ b/rtl/gpu.vhd
@@ -23,6 +23,14 @@ entity gpu is
       fpscountOn           : in  std_logic;
       noTexture            : in  std_logic;
       debugmodeOn          : in  std_logic;
+
+      gun1CrosshairOn      : in  std_logic;
+      gun1X                : in  integer range 0 to 255;
+      gun1Y                : in  integer range 0 to 255;
+
+      gun2CrosshairOn      : in  std_logic;
+      gun2X                : in  integer range 0 to 255;
+      gun2Y                : in  integer range 0 to 255;
       
       cdSlow               : in  std_logic;
       
@@ -1675,6 +1683,14 @@ begin
          
       fpscountOn              => fpscountOn,
       fpscountBCD             => fpscountBCD,
+
+      gun1CrosshairOn         => gun1CrosshairOn,
+      gun1X                   => gun1X,
+      gun1Y                   => gun1Y,
+
+      gun2CrosshairOn         => gun2CrosshairOn,
+      gun2X                   => gun2X,
+      gun2Y                   => gun2Y,
       
       debug_lateSamples       => debug_lateSamples,
       debug_lateTicks         => debug_lateTicks, 
@@ -1690,6 +1706,7 @@ begin
       lineInNext              => videoout_lineInNext,
       nextHCount              => nextHCount,
       DisplayWidth            => DisplayWidth,
+      DisplayHeight           => DisplayHeight,
       DisplayOffsetX          => DisplayOffsetX,
       DisplayOffsetY          => DisplayOffsetY,
       GPUSTAT_HorRes2         => GPUSTAT_HorRes2,

--- a/rtl/gpu.vhd
+++ b/rtl/gpu.vhd
@@ -26,11 +26,11 @@ entity gpu is
 
       Gun1CrosshairOn      : in  std_logic;
       Gun1X                : in  unsigned(7 downto 0);
-      Gun1Y                : in  unsigned(7 downto 0);
+      Gun1Y_scanlines      : in  unsigned(8 downto 0);
 
       Gun2CrosshairOn      : in  std_logic;
       Gun2X                : in  unsigned(7 downto 0);
-      Gun2Y                : in  unsigned(7 downto 0);
+      Gun2Y_scanlines      : in  unsigned(8 downto 0);
       
       cdSlow               : in  std_logic;
       
@@ -1686,11 +1686,11 @@ begin
 
       Gun1CrosshairOn         => Gun1CrosshairOn,
       Gun1X                   => Gun1X,
-      Gun1Y                   => Gun1Y,
+      Gun1Y_scanlines         => Gun1Y_scanlines,
 
       Gun2CrosshairOn         => Gun2CrosshairOn,
       Gun2X                   => Gun2X,
-      Gun2Y                   => Gun2Y,
+      Gun2Y_scanlines         => Gun2Y_scanlines,
       
       debug_lateSamples       => debug_lateSamples,
       debug_lateTicks         => debug_lateTicks, 
@@ -1706,7 +1706,6 @@ begin
       lineInNext              => videoout_lineInNext,
       nextHCount              => nextHCount,
       DisplayWidth            => DisplayWidth,
-      DisplayHeight           => DisplayHeight,
       DisplayOffsetX          => DisplayOffsetX,
       DisplayOffsetY          => DisplayOffsetY,
       GPUSTAT_HorRes2         => GPUSTAT_HorRes2,

--- a/rtl/gpu_videoout.vhd
+++ b/rtl/gpu_videoout.vhd
@@ -18,13 +18,13 @@ entity gpu_videoout is
       fpscountOn              : in  std_logic;
       fpscountBCD             : in  unsigned(7 downto 0);     
 
-      gun1CrosshairOn         : in  std_logic;
-      gun1X                   : in  integer range 0 to 255;
-      gun1Y                   : in  integer range 0 to 255;
+      Gun1CrosshairOn         : in  std_logic;
+      Gun1X                   : in  unsigned(7 downto 0);
+      Gun1Y                   : in  unsigned(7 downto 0);
 
-      gun2CrosshairOn         : in  std_logic;
-      gun2X                   : in  integer range 0 to 255;
-      gun2Y                   : in  integer range 0 to 255;
+      Gun2CrosshairOn         : in  std_logic;
+      Gun2X                   : in  unsigned(7 downto 0);
+      Gun2Y                   : in  unsigned(7 downto 0);
 
       debug_lateSamples       : in  unsigned(15 downto 0);
       debug_lateTicks         : in  unsigned(15 downto 0);      
@@ -139,13 +139,13 @@ architecture arch of gpu_videoout is
    signal debugtextDbg_data   : std_logic_vector(23 downto 0);
    signal debugtextDbg_ena    : std_logic;
 
-   signal overlay_gun1_ena    : std_logic;
-   signal overlay_gun2_ena    : std_logic;
+   signal overlay_Gun1_ena    : std_logic;
+   signal overlay_Gun2_ena    : std_logic;
 
-   signal gun1X_screen        : integer range 0 to 1023;
-   signal gun1Y_screen        : integer range 0 to 1023;
-   signal gun2X_screen        : integer range 0 to 1023;
-   signal gun2Y_screen        : integer range 0 to 1023;
+   signal Gun1X_screen        : integer range 0 to 1023;
+   signal Gun1Y_screen        : integer range 0 to 1023;
+   signal Gun2X_screen        : integer range 0 to 1023;
+   signal Gun2Y_screen        : integer range 0 to 1023;
    
 begin 
 
@@ -292,11 +292,11 @@ begin
                      video_r      <= debugtextDbg_data( 7 downto 0);
                      video_g      <= debugtextDbg_data(15 downto 8);
                      video_b      <= debugtextDbg_data(23 downto 16);
-                  elsif (overlay_gun1_ena = '1') then
+                  elsif (overlay_Gun1_ena = '1') then
                      video_r      <= (others => '1');
                      video_g      <= (others => '0');
                      video_b      <= (others => '0');
-                  elsif (overlay_gun2_ena = '1') then
+                  elsif (overlay_Gun2_ena = '1') then
                      video_r      <= (others => '0');
                      video_g      <= (others => '1');
                      video_b      <= (others => '1');
@@ -529,20 +529,20 @@ begin
    );
 
    -- Map gun coordinates (0-255 X, Y) to screen positions
-   gun1X_screen <= to_integer(to_unsigned(to_integer(DisplayWidth * to_unsigned(gun1X, 8)), 24) (17 downto 8));
-   gun2X_screen <= to_integer(to_unsigned(to_integer(DisplayWidth * to_unsigned(gun2X, 8)), 24) (17 downto 8));
+   Gun1X_screen <= to_integer(to_unsigned(to_integer(DisplayWidth * Gun1X), 18) (17 downto 8));
+   Gun2X_screen <= to_integer(to_unsigned(to_integer(DisplayWidth * Gun2X), 18) (17 downto 8));
 
-   gun1Y_screen <= to_integer(to_unsigned(to_integer(DisplayHeight * to_unsigned(gun1Y, 8)), 24) (16 downto 8));
-   gun2Y_screen <= to_integer(to_unsigned(to_integer(DisplayHeight * to_unsigned(gun2Y, 8)), 24) (16 downto 8));
+   Gun1Y_screen <= to_integer(to_unsigned(to_integer(DisplayHeight * Gun1Y), 17) (16 downto 8));
+   Gun2Y_screen <= to_integer(to_unsigned(to_integer(DisplayHeight * Gun2Y), 17) (16 downto 8));
 
    -- Lightgun crosshairs
-   overlay_gun1_ena <= '1' when gun1CrosshairOn = '1' and (
-                       (xpos = gun1X_screen and to_integer(lineDisp) > gun1Y_screen - 3 and to_integer(lineDisp) < gun1Y_screen + 3)
-                       or (to_integer(lineDisp) = gun1Y_screen and xpos > gun1X_screen - 3 and xpos < gun1X_screen + 3)
+   overlay_Gun1_ena <= '1' when Gun1CrosshairOn = '1' and (
+                       (xpos = Gun1X_screen and to_integer(lineDisp) > Gun1Y_screen - 3 and to_integer(lineDisp) < Gun1Y_screen + 3)
+                       or (to_integer(lineDisp) = Gun1Y_screen and xpos > Gun1X_screen - 3 and xpos < Gun1X_screen + 3)
                ) else '0';
-   overlay_gun2_ena <= '1' when gun2CrosshairOn = '1' and (
-                       (xpos = gun2X_screen and to_integer(lineDisp) > gun2Y_screen - 3 and to_integer(lineDisp) < gun2Y_screen + 3)
-                       or (to_integer(lineDisp) = gun2Y_screen and xpos > gun2X_screen - 3 and xpos < gun2X_screen + 3)
+   overlay_Gun2_ena <= '1' when Gun2CrosshairOn = '1' and (
+                       (xpos = Gun2X_screen and to_integer(lineDisp) > Gun2Y_screen - 3 and to_integer(lineDisp) < Gun2Y_screen + 3)
+                       or (to_integer(lineDisp) = Gun2Y_screen and xpos > Gun2X_screen - 3 and xpos < Gun2X_screen + 3)
                ) else '0';
 
 end architecture;

--- a/rtl/gpu_videoout.vhd
+++ b/rtl/gpu_videoout.vhd
@@ -18,6 +18,14 @@ entity gpu_videoout is
       fpscountOn              : in  std_logic;
       fpscountBCD             : in  unsigned(7 downto 0);     
 
+      gun1CrosshairOn         : in  std_logic;
+      gun1X                   : in  integer range 0 to 255;
+      gun1Y                   : in  integer range 0 to 255;
+
+      gun2CrosshairOn         : in  std_logic;
+      gun2X                   : in  integer range 0 to 255;
+      gun2Y                   : in  integer range 0 to 255;
+
       debug_lateSamples       : in  unsigned(15 downto 0);
       debug_lateTicks         : in  unsigned(15 downto 0);      
          
@@ -32,6 +40,7 @@ entity gpu_videoout is
       lineInNext              : in  unsigned(8 downto 0);
       nextHCount              : in  integer range 0 to 4095;
       DisplayWidth            : in  unsigned(9 downto 0);
+      DisplayHeight           : in  unsigned(8 downto 0);
       DisplayOffsetX          : in  unsigned(9 downto 0);
       DisplayOffsetY          : in  unsigned(8 downto 0);
       GPUSTAT_HorRes2         : in  std_logic;
@@ -129,6 +138,14 @@ architecture arch of gpu_videoout is
    signal debugtextDbg        : unsigned(23 downto 0);
    signal debugtextDbg_data   : std_logic_vector(23 downto 0);
    signal debugtextDbg_ena    : std_logic;
+
+   signal overlay_gun1_ena    : std_logic;
+   signal overlay_gun2_ena    : std_logic;
+
+   signal gun1X_screen        : integer range 0 to 1023;
+   signal gun1Y_screen        : integer range 0 to 1023;
+   signal gun2X_screen        : integer range 0 to 1023;
+   signal gun2Y_screen        : integer range 0 to 1023;
    
 begin 
 
@@ -275,6 +292,14 @@ begin
                      video_r      <= debugtextDbg_data( 7 downto 0);
                      video_g      <= debugtextDbg_data(15 downto 8);
                      video_b      <= debugtextDbg_data(23 downto 16);
+                  elsif (overlay_gun1_ena = '1') then
+                     video_r      <= (others => '1');
+                     video_g      <= (others => '0');
+                     video_b      <= (others => '0');
+                  elsif (overlay_gun2_ena = '1') then
+                     video_r      <= (others => '0');
+                     video_g      <= (others => '1');
+                     video_b      <= (others => '1');
                   elsif (GPUSTAT_DisplayDisable = '1') then
                      video_r      <= (others => '0');
                      video_g      <= (others => '0');
@@ -503,6 +528,22 @@ begin
       textstring             => x"444247"
    );
 
+   -- Map gun coordinates (0-255 X, Y) to screen positions
+   gun1X_screen <= to_integer(to_unsigned(to_integer(DisplayWidth * to_unsigned(gun1X, 8)), 24) (17 downto 8));
+   gun2X_screen <= to_integer(to_unsigned(to_integer(DisplayWidth * to_unsigned(gun2X, 8)), 24) (17 downto 8));
+
+   gun1Y_screen <= to_integer(to_unsigned(to_integer(DisplayHeight * to_unsigned(gun1Y, 8)), 24) (16 downto 8));
+   gun2Y_screen <= to_integer(to_unsigned(to_integer(DisplayHeight * to_unsigned(gun2Y, 8)), 24) (16 downto 8));
+
+   -- Lightgun crosshairs
+   overlay_gun1_ena <= '1' when gun1CrosshairOn = '1' and (
+                       (xpos = gun1X_screen and to_integer(lineDisp) > gun1Y_screen - 3 and to_integer(lineDisp) < gun1Y_screen + 3)
+                       or (to_integer(lineDisp) = gun1Y_screen and xpos > gun1X_screen - 3 and xpos < gun1X_screen + 3)
+               ) else '0';
+   overlay_gun2_ena <= '1' when gun2CrosshairOn = '1' and (
+                       (xpos = gun2X_screen and to_integer(lineDisp) > gun2Y_screen - 3 and to_integer(lineDisp) < gun2Y_screen + 3)
+                       or (to_integer(lineDisp) = gun2Y_screen and xpos > gun2X_screen - 3 and xpos < gun2X_screen + 3)
+               ) else '0';
 
 end architecture;
 

--- a/rtl/gpu_videoout.vhd
+++ b/rtl/gpu_videoout.vhd
@@ -20,11 +20,11 @@ entity gpu_videoout is
 
       Gun1CrosshairOn         : in  std_logic;
       Gun1X                   : in  unsigned(7 downto 0);
-      Gun1Y                   : in  unsigned(7 downto 0);
+      Gun1Y_scanlines         : in  unsigned(8 downto 0);
 
       Gun2CrosshairOn         : in  std_logic;
       Gun2X                   : in  unsigned(7 downto 0);
-      Gun2Y                   : in  unsigned(7 downto 0);
+      Gun2Y_scanlines         : in  unsigned(8 downto 0);
 
       debug_lateSamples       : in  unsigned(15 downto 0);
       debug_lateTicks         : in  unsigned(15 downto 0);      
@@ -40,7 +40,6 @@ entity gpu_videoout is
       lineInNext              : in  unsigned(8 downto 0);
       nextHCount              : in  integer range 0 to 4095;
       DisplayWidth            : in  unsigned(9 downto 0);
-      DisplayHeight           : in  unsigned(8 downto 0);
       DisplayOffsetX          : in  unsigned(9 downto 0);
       DisplayOffsetY          : in  unsigned(8 downto 0);
       GPUSTAT_HorRes2         : in  std_logic;
@@ -143,9 +142,10 @@ architecture arch of gpu_videoout is
    signal overlay_Gun2_ena    : std_logic;
 
    signal Gun1X_screen        : integer range 0 to 1023;
-   signal Gun1Y_screen        : integer range 0 to 1023;
    signal Gun2X_screen        : integer range 0 to 1023;
-   signal Gun2Y_screen        : integer range 0 to 1023;
+
+   signal Gun1Y_screen        : unsigned(9 downto 0);
+   signal Gun2Y_screen        : unsigned(9 downto 0);
    
 begin 
 
@@ -532,8 +532,8 @@ begin
    Gun1X_screen <= to_integer(to_unsigned(to_integer(DisplayWidth * Gun1X), 18) (17 downto 8));
    Gun2X_screen <= to_integer(to_unsigned(to_integer(DisplayWidth * Gun2X), 18) (17 downto 8));
 
-   Gun1Y_screen <= to_integer(to_unsigned(to_integer(DisplayHeight * Gun1Y), 17) (16 downto 8));
-   Gun2Y_screen <= to_integer(to_unsigned(to_integer(DisplayHeight * Gun2Y), 17) (16 downto 8));
+   Gun1Y_screen <= '0' & Gun1Y_scanlines when interlacedMode = '0' else Gun1Y_scanlines & '0';
+   Gun2Y_screen <= '0' & Gun2Y_scanlines when interlacedMode = '0' else Gun2Y_scanlines & '0';
 
    -- Lightgun crosshairs
    overlay_Gun1_ena <= '1' when Gun1CrosshairOn = '1' and (

--- a/rtl/joypad.vhd
+++ b/rtl/joypad.vhd
@@ -60,6 +60,10 @@ entity joypad is
       MouseRight           : in  std_logic;
       MouseX               : in  signed(8 downto 0);
       MouseY               : in  signed(8 downto 0);
+      gun1X                : in  unsigned(7 downto 0);
+      gun1Y                : in  unsigned(7 downto 0);
+      gun2X                : in  unsigned(7 downto 0);
+      gun2Y                : in  unsigned(7 downto 0);
 
       mem1_request         : out std_logic;
       mem1_BURSTCNT        : out std_logic_vector(7 downto 0) := (others => '0'); 
@@ -407,7 +411,9 @@ begin
       MouseLeft            => MouseLeft,
       MouseRight           => MouseRight,
       MouseX               => MouseX,
-      MouseY               => MouseY
+      MouseY               => MouseY,
+      GunX                 => Gun1X,
+      GunY                 => Gun1Y
    );
    
    ijoypad_pad2 : entity work.joypad_pad
@@ -461,7 +467,9 @@ begin
       MouseLeft            => MouseLeft,
       MouseRight           => MouseRight,
       MouseX               => MouseX,
-      MouseY               => MouseY
+      MouseY               => MouseY,
+      GunX                 => Gun2X,
+      GunY                 => Gun2Y
    );
    
    ijoypad_mem1 : entity work.joypad_mem

--- a/rtl/joypad.vhd
+++ b/rtl/joypad.vhd
@@ -61,11 +61,11 @@ entity joypad is
       MouseX               : in  signed(8 downto 0);
       MouseY               : in  signed(8 downto 0);
       Gun1X                : in  unsigned(7 downto 0);
-      Gun1Y                : in  unsigned(7 downto 0);
       Gun2X                : in  unsigned(7 downto 0);
-      Gun2Y                : in  unsigned(7 downto 0);
       Gun1Y_scanlines      : in  unsigned(8 downto 0);
       Gun2Y_scanlines      : in  unsigned(8 downto 0);
+      Gun1AimOffscreen     : in  std_logic;
+      Gun2AimOffscreen     : in  std_logic;
 
       mem1_request         : out std_logic;
       mem1_BURSTCNT        : out std_logic_vector(7 downto 0) := (others => '0'); 
@@ -415,8 +415,8 @@ begin
       MouseX               => MouseX,
       MouseY               => MouseY,
       GunX                 => Gun1X,
-      GunY                 => Gun1Y,
-      GunY_scanlines       => Gun1Y_scanlines
+      GunY_scanlines       => Gun1Y_scanlines,
+      GunAimOffscreen      => Gun1AimOffscreen
    );
    
    ijoypad_pad2 : entity work.joypad_pad
@@ -472,8 +472,8 @@ begin
       MouseX               => MouseX,
       MouseY               => MouseY,
       GunX                 => Gun2X,
-      GunY                 => Gun2Y,
-      GunY_scanlines       => Gun2Y_scanlines
+      GunY_scanlines       => Gun2Y_scanlines,
+      GunAimOffscreen      => Gun2AimOffscreen
    );
    
    ijoypad_mem1 : entity work.joypad_mem

--- a/rtl/joypad.vhd
+++ b/rtl/joypad.vhd
@@ -60,10 +60,12 @@ entity joypad is
       MouseRight           : in  std_logic;
       MouseX               : in  signed(8 downto 0);
       MouseY               : in  signed(8 downto 0);
-      gun1X                : in  unsigned(7 downto 0);
-      gun1Y                : in  unsigned(7 downto 0);
-      gun2X                : in  unsigned(7 downto 0);
-      gun2Y                : in  unsigned(7 downto 0);
+      Gun1X                : in  unsigned(7 downto 0);
+      Gun1Y                : in  unsigned(7 downto 0);
+      Gun2X                : in  unsigned(7 downto 0);
+      Gun2Y                : in  unsigned(7 downto 0);
+      Gun1Y_scanlines      : in  unsigned(8 downto 0);
+      Gun2Y_scanlines      : in  unsigned(8 downto 0);
 
       mem1_request         : out std_logic;
       mem1_BURSTCNT        : out std_logic_vector(7 downto 0) := (others => '0'); 
@@ -413,7 +415,8 @@ begin
       MouseX               => MouseX,
       MouseY               => MouseY,
       GunX                 => Gun1X,
-      GunY                 => Gun1Y
+      GunY                 => Gun1Y,
+      GunY_scanlines       => Gun1Y_scanlines
    );
    
    ijoypad_pad2 : entity work.joypad_pad
@@ -469,7 +472,8 @@ begin
       MouseX               => MouseX,
       MouseY               => MouseY,
       GunX                 => Gun2X,
-      GunY                 => Gun2Y
+      GunY                 => Gun2Y,
+      GunY_scanlines       => Gun2Y_scanlines
    );
    
    ijoypad_mem1 : entity work.joypad_mem

--- a/rtl/joypad_pad.vhd
+++ b/rtl/joypad_pad.vhd
@@ -55,8 +55,8 @@ entity joypad_pad is
       MouseX               : in  signed(8 downto 0);
       MouseY               : in  signed(8 downto 0);
       GunX                 : in  unsigned(7 downto 0);
-      GunY                 : in  unsigned(7 downto 0);
-      GunY_scanlines       : in  unsigned(8 downto 0)
+      GunY_scanlines       : in  unsigned(8 downto 0);
+      GunAimOffscreen      : in  std_logic
    );
 end entity;
 
@@ -290,7 +290,7 @@ begin
                            ack             <= '1';
                            receiveValid    <= '1';
 
-                           if KeyTriangle = '1' or GunX = x"00" or GunX = x"FF" or GunY = x"00" or GunY = x"FF" then
+                           if KeyTriangle = '1' or GunAimOffscreen = '1' then
                               gunOffscreen <= '1';
                            else
                               gunOffscreen <= '0';

--- a/rtl/joypad_pad.vhd
+++ b/rtl/joypad_pad.vhd
@@ -55,7 +55,8 @@ entity joypad_pad is
       MouseX               : in  signed(8 downto 0);
       MouseY               : in  signed(8 downto 0);
       GunX                 : in  unsigned(7 downto 0);
-      GunY                 : in  unsigned(7 downto 0)
+      GunY                 : in  unsigned(7 downto 0);
+      GunY_scanlines       : in  unsigned(8 downto 0)
    );
 end entity;
 
@@ -310,9 +311,9 @@ begin
                            receiveValid     <= '1';
 
                            -- GunCon reports X as # of 8MHz clks since HSYNC (01h=Error, or 04Dh..1CDh).
-                           -- Map from joystick's +/-128 to GunCon range.
+                           -- Map from joystick's +/-128 to GunCon range (8MHz clocks): (GunX * 384/256) + 67
                            if gunOffscreen = '0' then
-                              gunConX_8MHz  <= std_logic_vector(to_unsigned(70, 9) + resize(GunX, 9) + resize(GunX(7 downto 1), 9) );
+                              gunConX_8MHz  <= std_logic_vector(to_unsigned(67, 9) + resize(GunX, 9) + resize(GunX(7 downto 1), 9) );
                            else
                               gunConX_8MHz  <= "000000001"; -- X: 0x0001, Y: 0x000A indicates no light / offscreen shot
                            end if;
@@ -339,10 +340,8 @@ begin
                            ack             <= '1';
 
                            -- GunCon reports Y as # of scanlines since VSYNC (05h/0Ah=Error, PAL=20h..127h, NTSC=19h..F8h)
-                           -- Map from joystick's +/-128 to GunCon range.
-                           -- TODO: report Analog1Y directly if in PAL(50)
                            if gunOffscreen = '0' then
-                              gunConY      <= std_logic_vector(unsigned(to_unsigned(240, 9) * GunY) (16 downto 8) + 16);
+                              gunConY      <= std_logic_vector(to_unsigned(16, 9) + GunY_scanlines);
                            else
                               gunConY      <= "000001010"; -- X: 0x0001, Y: 0x000A indicates no light / offscreen shot
                            end if;

--- a/rtl/psx_top.vhd
+++ b/rtl/psx_top.vhd
@@ -475,6 +475,8 @@ architecture arch of psx_top is
    signal Gun2Y                  : unsigned(7 downto 0);
    signal Gun1Y_scanlines        : unsigned(8 downto 0);
    signal Gun2Y_scanlines        : unsigned(8 downto 0);
+   signal Gun1AimOffscreen       : std_logic;
+   signal Gun2AimOffscreen       : std_logic;
 
    -- memcard
    signal memcard1_pause         : std_logic;
@@ -870,9 +872,6 @@ begin
       SS_DataRead          => SS_DataRead_MEMORY      
    );
 
-   Gun1CrosshairOn <= '1' when showGunCrosshairs = '1' and PadPortGunCon1 = '1' else '0';
-   Gun2CrosshairOn <= '1' when showGunCrosshairs = '1' and PadPortGunCon2 = '1' else '0';
-
    -- Gun coordinate mapping is toplevel so that the gun's
    -- coordinates can be passed to both joypad
    -- and GPU (for crosshair overlays)
@@ -881,6 +880,12 @@ begin
 
    Gun1Y <= to_unsigned(to_integer(Analog1YP1 + 128), 8);
    Gun2Y <= to_unsigned(to_integer(Analog1YP2 + 128), 8);
+
+   Gun1AimOffscreen <= '1' when Gun1X = x"00" or Gun1X = x"FF" or Gun1Y = x"00" or Gun1Y = x"FF" else '0';
+   Gun2AimOffscreen <= '1' when Gun2X = x"00" or Gun2X = x"FF" or Gun2Y = x"00" or Gun2Y = x"FF" else '0';
+
+   Gun1CrosshairOn <= '1' when showGunCrosshairs = '1' and PadPortGunCon1 = '1' and Gun1AimOffscreen = '0' else '0';
+   Gun2CrosshairOn <= '1' when showGunCrosshairs = '1' and PadPortGunCon2 = '1' and Gun2AimOffscreen = '0' else '0';
 
    Gun1Y_scanlines <= resize(Gun1Y, 9) + resize(Gun1Y(7 downto 3), 9)       -- Gun1Y * 288 / 256
                       when (isPal = '1' and pal60 = '0')
@@ -945,11 +950,11 @@ begin
       MouseX               => MouseX,
       MouseY               => MouseY,
       Gun1X                => Gun1X,
-      Gun1Y                => Gun1Y,
       Gun2X                => Gun2X,
-      Gun2Y                => Gun2Y,
       Gun1Y_scanlines      => Gun1Y_scanlines,
       Gun2Y_scanlines      => Gun2Y_scanlines,
+      Gun1AimOffscreen     => Gun1AimOffscreen,
+      Gun2AimOffscreen     => Gun2AimOffscreen,
       
       mem1_request         => memDDR3card1_request,   
       mem1_BURSTCNT        => memDDR3card1_BURSTCNT,  

--- a/rtl/psx_top.vhd
+++ b/rtl/psx_top.vhd
@@ -473,6 +473,8 @@ architecture arch of psx_top is
    signal Gun1Y                  : unsigned(7 downto 0);
    signal Gun2X                  : unsigned(7 downto 0);
    signal Gun2Y                  : unsigned(7 downto 0);
+   signal Gun1Y_scanlines        : unsigned(8 downto 0);
+   signal Gun2Y_scanlines        : unsigned(8 downto 0);
 
    -- memcard
    signal memcard1_pause         : std_logic;
@@ -880,6 +882,14 @@ begin
    Gun1Y <= to_unsigned(to_integer(Analog1YP1 + 128), 8);
    Gun2Y <= to_unsigned(to_integer(Analog1YP2 + 128), 8);
 
+   Gun1Y_scanlines <= resize(Gun1Y, 9) + resize(Gun1Y(7 downto 3), 9)       -- Gun1Y * 288 / 256
+                      when (isPal = '1' and pal60 = '0')
+                      else resize(Gun1Y, 9) - resize(Gun1Y(7 downto 4), 9); -- Gun1Y * 240 / 256
+
+   Gun2Y_scanlines <= resize(Gun2Y, 9) + resize(Gun2Y(7 downto 3), 9)       -- Gun1Y * 288 / 256
+                      when (isPal = '1' and pal60 = '0')
+                      else resize(Gun2Y, 9) - resize(Gun2Y(7 downto 4), 9); -- Gun1Y * 240 / 256
+
    ijoypad: entity work.joypad
    port map 
    (
@@ -938,6 +948,8 @@ begin
       Gun1Y                => Gun1Y,
       Gun2X                => Gun2X,
       Gun2Y                => Gun2Y,
+      Gun1Y_scanlines      => Gun1Y_scanlines,
+      Gun2Y_scanlines      => Gun2Y_scanlines,
       
       mem1_request         => memDDR3card1_request,   
       mem1_BURSTCNT        => memDDR3card1_BURSTCNT,  
@@ -1252,11 +1264,11 @@ begin
       
       Gun1CrosshairOn      => Gun1CrosshairOn,
       Gun1X                => Gun1X,
-      Gun1Y                => Gun1Y,
+      Gun1Y_scanlines      => Gun1Y_scanlines,
 
       Gun2CrosshairOn      => Gun2CrosshairOn,
       Gun2X                => Gun2X,
-      Gun2Y                => Gun2Y,
+      Gun2Y_scanlines      => Gun2Y_scanlines,
 
       cdSlow               => cdSlow,
       

--- a/rtl/psx_top.vhd
+++ b/rtl/psx_top.vhd
@@ -465,7 +465,15 @@ architecture arch of psx_top is
    signal debug_lateTicks        : unsigned(15 downto 0);
    
    signal debugmodeOn            : std_logic;
-   
+
+   signal showGunCrosshairs      : std_logic := '1';
+   signal gun1CrosshairOn        : std_logic;
+   signal gun2CrosshairOn        : std_logic;
+   signal gun1X                  : integer range 0 to 1023;
+   signal gun1Y                  : integer range 0 to 511;
+   signal gun2X                  : integer range 0 to 1023;
+   signal gun2Y                  : integer range 0 to 511;
+
    -- memcard
    signal memcard1_pause         : std_logic;
    signal memcard2_pause         : std_logic;
@@ -1207,6 +1215,17 @@ begin
    
    
    hblank <= hblank_intern;
+
+   gun1CrosshairOn <= '1' when showGunCrosshairs = '1' and PadPortGunCon1 = '1' else '0';
+   gun2CrosshairOn <= '1' when showGunCrosshairs = '1' and PadPortGunCon2 = '1' else '0';
+
+   -- Gun coordinate mapping is toplevel so that the gun's
+   -- coordinates can be passed to GPU for crosshair overlays.
+   gun1X <= to_integer(Analog1XP1 + 128);
+   gun2X <= to_integer(Analog1XP2 + 128);
+
+   gun1Y <= to_integer(Analog1YP1 + 128);
+   gun2Y <= to_integer(Analog1YP2 + 128);
    
    igpu : entity work.gpu
    port map
@@ -1226,6 +1245,14 @@ begin
       noTexture            => noTexture,
       debugmodeOn          => debugmodeOn,
       
+      gun1CrosshairOn      => gun1CrosshairOn,
+      gun1X                => gun1X,
+      gun1Y                => gun1Y,
+
+      gun2CrosshairOn      => gun2CrosshairOn,
+      gun2X                => gun2X,
+      gun2Y                => gun2Y,
+
       cdSlow               => cdSlow,
       
       errorOn              => errorOn,  

--- a/rtl/psx_top.vhd
+++ b/rtl/psx_top.vhd
@@ -467,12 +467,12 @@ architecture arch of psx_top is
    signal debugmodeOn            : std_logic;
 
    signal showGunCrosshairs      : std_logic := '1';
-   signal gun1CrosshairOn        : std_logic;
-   signal gun2CrosshairOn        : std_logic;
-   signal gun1X                  : integer range 0 to 1023;
-   signal gun1Y                  : integer range 0 to 511;
-   signal gun2X                  : integer range 0 to 1023;
-   signal gun2Y                  : integer range 0 to 511;
+   signal Gun1CrosshairOn        : std_logic;
+   signal Gun2CrosshairOn        : std_logic;
+   signal Gun1X                  : unsigned(7 downto 0);
+   signal Gun1Y                  : unsigned(7 downto 0);
+   signal Gun2X                  : unsigned(7 downto 0);
+   signal Gun2Y                  : unsigned(7 downto 0);
 
    -- memcard
    signal memcard1_pause         : std_logic;
@@ -868,6 +868,18 @@ begin
       SS_DataRead          => SS_DataRead_MEMORY      
    );
 
+   Gun1CrosshairOn <= '1' when showGunCrosshairs = '1' and PadPortGunCon1 = '1' else '0';
+   Gun2CrosshairOn <= '1' when showGunCrosshairs = '1' and PadPortGunCon2 = '1' else '0';
+
+   -- Gun coordinate mapping is toplevel so that the gun's
+   -- coordinates can be passed to both joypad
+   -- and GPU (for crosshair overlays)
+   Gun1X <= to_unsigned(to_integer(Analog1XP1 + 128), 8);
+   Gun2X <= to_unsigned(to_integer(Analog1XP2 + 128), 8);
+
+   Gun1Y <= to_unsigned(to_integer(Analog1YP1 + 128), 8);
+   Gun2Y <= to_unsigned(to_integer(Analog1YP2 + 128), 8);
+
    ijoypad: entity work.joypad
    port map 
    (
@@ -922,6 +934,10 @@ begin
       MouseRight           => MouseRight,
       MouseX               => MouseX,
       MouseY               => MouseY,
+      Gun1X                => Gun1X,
+      Gun1Y                => Gun1Y,
+      Gun2X                => Gun2X,
+      Gun2Y                => Gun2Y,
       
       mem1_request         => memDDR3card1_request,   
       mem1_BURSTCNT        => memDDR3card1_BURSTCNT,  
@@ -1216,17 +1232,6 @@ begin
    
    hblank <= hblank_intern;
 
-   gun1CrosshairOn <= '1' when showGunCrosshairs = '1' and PadPortGunCon1 = '1' else '0';
-   gun2CrosshairOn <= '1' when showGunCrosshairs = '1' and PadPortGunCon2 = '1' else '0';
-
-   -- Gun coordinate mapping is toplevel so that the gun's
-   -- coordinates can be passed to GPU for crosshair overlays.
-   gun1X <= to_integer(Analog1XP1 + 128);
-   gun2X <= to_integer(Analog1XP2 + 128);
-
-   gun1Y <= to_integer(Analog1YP1 + 128);
-   gun2Y <= to_integer(Analog1YP2 + 128);
-   
    igpu : entity work.gpu
    port map
    (
@@ -1245,13 +1250,13 @@ begin
       noTexture            => noTexture,
       debugmodeOn          => debugmodeOn,
       
-      gun1CrosshairOn      => gun1CrosshairOn,
-      gun1X                => gun1X,
-      gun1Y                => gun1Y,
+      Gun1CrosshairOn      => Gun1CrosshairOn,
+      Gun1X                => Gun1X,
+      Gun1Y                => Gun1Y,
 
-      gun2CrosshairOn      => gun2CrosshairOn,
-      gun2X                => gun2X,
-      gun2Y                => gun2Y,
+      Gun2CrosshairOn      => Gun2CrosshairOn,
+      Gun2X                => Gun2X,
+      Gun2Y                => Gun2Y,
 
       cdSlow               => cdSlow,
       


### PR DESCRIPTION
ALMs without SignalTap: 37,205 / 41,910 (89%). Two changes:

1. The coordinates of the GunCon are now calculated accurately. This turned out to be doable without any full integer multiplications.

2. When a pad is set to GunCon mode, it will now show a small crosshair at all times. Unlike the GunCon coordinate mapping, I did use two integer multiplies here - one for each crosshair's on-screen X position. It might be possible to economize those - see gpu_videoout.vhd.

I intended to use the existing gpu_overlay module for the cursors, but the offsets for that module use generics, and I didn't want to make them ports. That said, this design could also be extended to provide different options for crosshair size, as some other cores' lightguns have.

The flag to show the cursors is currently hard-coded to 1, but it could be converted to an OSD option.