### PR TITLE
GunCon: single-pixel crosshair, 240 scanlines for PAL

### DIFF
--- a/rtl/gpu_videoout.vhd
+++ b/rtl/gpu_videoout.vhd
@@ -535,18 +535,24 @@ begin
    Gun1Y_screen <= '0' & Gun1Y_scanlines when interlacedMode = '0' else Gun1Y_scanlines & '0';
    Gun2Y_screen <= '0' & Gun2Y_scanlines when interlacedMode = '0' else Gun2Y_scanlines & '0';
 
-   -- Lightgun crosshairs
-   --overlay_Gun1_ena <= '1' when Gun1CrosshairOn = '1' and (
-   --                    (xpos = Gun1X_screen and to_integer(lineDisp) > Gun1Y_screen - 3 and to_integer(lineDisp) < Gun1Y_screen + 3)
-   --                    or (to_integer(lineDisp) = Gun1Y_screen and xpos > Gun1X_screen - 3 and xpos < Gun1X_screen + 3)
-   --            ) else '0';
-   --overlay_Gun2_ena <= '1' when Gun2CrosshairOn = '1' and (
-   --                    (xpos = Gun2X_screen and to_integer(lineDisp) > Gun2Y_screen - 3 and to_integer(lineDisp) < Gun2Y_screen + 3)
-   --                    or (to_integer(lineDisp) = Gun2Y_screen and xpos > Gun2X_screen - 3 and xpos < Gun2X_screen + 3)
-   --            ) else '0';
-   
-   overlay_Gun1_ena <= '0';
-   overlay_Gun2_ena <= '0';
+   -- Lightgun crosshairs (currently single pixel to save resources)
+   process (clk2x)
+   begin
+      if rising_edge(clk2x) then
+         if (video_ce = '1') then
+            overlay_Gun1_ena <= '0';
+            overlay_Gun2_ena <= '0';
+
+            if (Gun1CrosshairOn = '1' and xpos = Gun1X_screen and to_integer(lineDisp) = Gun1Y_screen) then
+               overlay_Gun1_ena <= '1';
+            end if;
+
+            if (Gun2CrosshairOn = '1' and xpos = Gun2X_screen and to_integer(lineDisp) = Gun2Y_screen) then
+               overlay_Gun2_ena <= '1';
+            end if;
+         end if;
+      end if;
+   end process;
 
 end architecture;
 

--- a/rtl/joypad.vhd
+++ b/rtl/joypad.vhd
@@ -12,6 +12,8 @@ entity joypad is
       clk2xIndex           : in  std_logic;
       ce                   : in  std_logic;
       reset                : in  std_logic;
+
+      isPal                : in  std_logic; -- passed through for GunCon
       
       PadPortEnable1       : in  std_logic;
       PadPortAnalog1       : in  std_logic;
@@ -374,6 +376,7 @@ begin
       isMouse              => PadPortMouse1,
       isGunCon             => PadPortGunCon1,
       isNeGcon             => PadPortNeGcon1,
+      isPal                => isPal,
 
       selected             => selectedPad1,
       actionNext           => actionNextPad,
@@ -431,6 +434,7 @@ begin
       isMouse              => PadPortMouse2,
       isGunCon             => PadPortGunCon2,
       isNeGcon             => PadPortNeGcon2,
+      isPal                => isPal,
 
       selected             => selectedPad2,
       actionNext           => actionNextPad,

--- a/rtl/joypad_pad.vhd
+++ b/rtl/joypad_pad.vhd
@@ -14,6 +14,7 @@ entity joypad_pad is
       isMouse              : in  std_logic;
       isGunCon             : in  std_logic;
       isNeGcon             : in  std_logic;
+      isPal                : in  std_logic;
       
       selected             : in  std_logic;
       actionNext           : in  std_logic := '0';
@@ -341,7 +342,11 @@ begin
 
                            -- GunCon reports Y as # of scanlines since VSYNC (05h/0Ah=Error, PAL=20h..127h, NTSC=19h..F8h)
                            if gunOffscreen = '0' then
-                              gunConY      <= std_logic_vector(to_unsigned(16, 9) + GunY_scanlines);
+                              if isPal = '1' then
+                                 gunConY      <= std_logic_vector(to_unsigned(40, 9) + GunY_scanlines);
+                              else
+                                 gunConY      <= std_logic_vector(to_unsigned(16, 9) + GunY_scanlines);
+                              end if;
                            else
                               gunConY      <= "000001010"; -- X: 0x0001, Y: 0x000A indicates no light / offscreen shot
                            end if;

--- a/rtl/psx_top.vhd
+++ b/rtl/psx_top.vhd
@@ -905,13 +905,9 @@ begin
    Gun1CrosshairOn <= '1' when showGunCrosshairs = '1' and PadPortGunCon1 = '1' and Gun1AimOffscreen = '0' else '0';
    Gun2CrosshairOn <= '1' when showGunCrosshairs = '1' and PadPortGunCon2 = '1' and Gun2AimOffscreen = '0' else '0';
 
-   Gun1Y_scanlines <= resize(Gun1Y, 9) + resize(Gun1Y(7 downto 3), 9)       -- Gun1Y * 288 / 256
-                      when (isPal = '1' and pal60 = '0')
-                      else resize(Gun1Y, 9) - resize(Gun1Y(7 downto 4), 9); -- Gun1Y * 240 / 256
-
-   Gun2Y_scanlines <= resize(Gun2Y, 9) + resize(Gun2Y(7 downto 3), 9)       -- Gun1Y * 288 / 256
-                      when (isPal = '1' and pal60 = '0')
-                      else resize(Gun2Y, 9) - resize(Gun2Y(7 downto 4), 9); -- Gun1Y * 240 / 256
+   -- Map the gun's Y coordinate to 240 scanlines
+   Gun1Y_scanlines <= resize(Gun1Y, 9) - resize(Gun1Y(7 downto 4), 9); -- Gun1Y * 240 / 256
+   Gun2Y_scanlines <= resize(Gun2Y, 9) - resize(Gun2Y(7 downto 4), 9); -- Gun1Y * 240 / 256
 
    ijoypad: entity work.joypad
    port map 
@@ -921,6 +917,8 @@ begin
       clk2xIndex           => clk2xIndex,
       ce                   => ce,   
       reset                => reset_intern,
+
+      isPal                => isPal, -- passed through for GunCon
       
       PadPortEnable1       => PadPortEnable1,
       PadPortAnalog1       => PadPortAnalog1,


### PR DESCRIPTION
1. The crosshair was previously disabled due to excessive resource use. I've brought it back, but with just a single pixel inside a clocked process. The resource use for gpu_videoout is only about 50 ALUTs higher than with no crosshair at all. One pixel is pretty difficult to see in practice, so it would still be ideal to eventually bring a larger cursor back later, if it can be done efficiently.

2. Improved gun position mapping on PAL games by just assuming all games have 240 visible scanlines. If a game has 256 visible scanlines, mapping could be a bit off for it, but I'm not aware of a PAL gun game that uses a 256p video mode.