### PR TITLE
add Konami Justifier lightgun support

### DIFF
--- a/PSX.sv
+++ b/PSX.sv
@@ -368,8 +368,8 @@ parameter CONF_STR = {
 	"-;",
 	"o78,System Type,NTSC-U,NTSC-J,PAL;",
 	"-;",
-	"oDG,Pad1,Digital,Analog,Mouse,Off,GunCon,NeGcon,Wheel-NegCon,Wheel-Analog,Dualshock;",
-	"oHK,Pad2,Digital,Analog,Mouse,Off,GunCon,NeGcon,Wheel-NegCon,Wheel-Analog,Dualshock;",
+	"oDG,Pad1,Digital,Analog,Mouse,Off,GunCon,NeGcon,Wheel-NegCon,Wheel-Analog,Dualshock,Justifier;",
+	"oHK,Pad2,Digital,Analog,Mouse,Off,GunCon,NeGcon,Wheel-NegCon,Wheel-Analog,Dualshock,Justifier;",
 	"h2O9,Show Crosshair,Off,On;",
 	"-;",
 	"OS,FPS Overlay,Off,On;",
@@ -446,7 +446,7 @@ parameter CONF_STR = {
 
 wire  [1:0] buttons;
 wire [63:0] status;
-wire [15:0] status_menumask = {(PadPortGunCon1 | PadPortGunCon2), SDRAM2_EN, 1'b0};
+wire [15:0] status_menumask = {(PadPortGunCon1 | PadPortGunCon2 | PadPortJustif1 | PadPortJustif2), SDRAM2_EN, 1'b0};
 wire        forced_scandoubler;
 reg  [31:0] sd_lba0 = 0;
 reg  [31:0] sd_lba1;
@@ -719,8 +719,8 @@ defparam savestate_ui.INFO_TIMEOUT_BITS = 25;
 // 0110 -> Wheel Negcon
 // 0111 -> Wheel Analog
 // 1000 -> DualShock
-// 1001 -> DualShock forced Analog
-// 1001..1111 -> reserved
+// 1001 -> Konami Justifier lightgun
+// 1010..1111 -> reserved
 
 wire PadPortEnable1 = (status[48:45] != 4'b0011);
 wire PadPortAnalog1 = (status[48:45] == 4'b0001) || (status[48:45] == 4'b0111);
@@ -728,7 +728,8 @@ wire PadPortMouse1  = (status[48:45] == 4'b0010);
 wire PadPortGunCon1 = (status[48:45] == 4'b0100);
 wire PadPortNeGcon1 = (status[48:45] == 4'b0101) || (status[48:45] == 4'b0110);
 wire PadPortWheel1  = (status[48:45] == 4'b0110) || (status[48:45] == 4'b0111);
-wire PadPortDS1     = (status[48:45] == 4'b1000) || (status[48:45] == 4'b1001);
+wire PadPortDS1     = (status[48:45] == 4'b1000);
+wire PadPortJustif1 = (status[48:45] == 4'b1001);
 
 wire PadPortEnable2 = (status[52:49] != 4'b0011);
 wire PadPortAnalog2 = (status[52:49] == 4'b0001) || (status[52:49] == 4'b0111);
@@ -736,7 +737,8 @@ wire PadPortMouse2  = (status[52:49] == 4'b0010);
 wire PadPortGunCon2 = (status[52:49] == 4'b0100);
 wire PadPortNeGcon2 = (status[52:49] == 4'b0101) || (status[52:49] == 4'b0110);
 wire PadPortWheel2  = (status[52:49] == 4'b0110) || (status[52:49] == 4'b0111);
-wire PadPortDS2     = (status[52:49] == 4'b1000) || (status[52:49] == 4'b1001);
+wire PadPortDS2     = (status[52:49] == 4'b1000);
+wire PadPortJustif2 = (status[52:49] == 4'b1001);
 
 wire [1:0] padMode;
 reg  [1:0] padMode_1;
@@ -916,6 +918,7 @@ psx
    .PadPortNeGcon1 (PadPortNeGcon1),
    .PadPortWheel1  (PadPortWheel1),
    .PadPortDS1     (PadPortDS1),
+   .PadPortJustif1 (PadPortJustif1),
    .PadPortEnable2 (PadPortEnable2),
    .PadPortAnalog2 (PadPortAnalog2),
    .PadPortMouse2  (PadPortMouse2 ),
@@ -923,6 +926,7 @@ psx
    .PadPortNeGcon2 (PadPortNeGcon2),
    .PadPortWheel2  (PadPortWheel2),
    .PadPortDS2     (PadPortDS2),
+   .PadPortJustif2 (PadPortJustif2),
    .KeyTriangle({joy2[4], joy[4] }),    
    .KeyCircle  ({joy2[5] ,joy[5] }),       
    .KeyCross   ({joy2[6] ,joy[6] }),       

--- a/rtl/gpu.vhd
+++ b/rtl/gpu.vhd
@@ -33,10 +33,12 @@ entity gpu is
       Gun1CrosshairOn      : in  std_logic;
       Gun1X                : in  unsigned(7 downto 0);
       Gun1Y_scanlines      : in  unsigned(8 downto 0);
+      Gun1IRQ10            : out std_logic;
 
       Gun2CrosshairOn      : in  std_logic;
       Gun2X                : in  unsigned(7 downto 0);
       Gun2Y_scanlines      : in  unsigned(8 downto 0);
+      Gun2IRQ10            : out std_logic;
       
       cdSlow               : in  std_logic;
       
@@ -1579,10 +1581,12 @@ begin
       Gun1CrosshairOn            => Gun1CrosshairOn,
       Gun1X                      => Gun1X,
       Gun1Y_scanlines            => Gun1Y_scanlines,
+      Gun1IRQ10                  => Gun1IRQ10,
    
       Gun2CrosshairOn            => Gun2CrosshairOn,
       Gun2X                      => Gun2X,
       Gun2Y_scanlines            => Gun2Y_scanlines,
+      Gun2IRQ10                  => Gun2IRQ10,
             
       cdSlow                     => cdSlow,      
                                  

--- a/rtl/gpu_videoout.vhd
+++ b/rtl/gpu_videoout.vhd
@@ -31,10 +31,12 @@ entity gpu_videoout is
       Gun1CrosshairOn            : in  std_logic;
       Gun1X                      : in  unsigned(7 downto 0);
       Gun1Y_scanlines            : in  unsigned(8 downto 0);
+      Gun1IRQ10                  : out std_logic;
    
       Gun2CrosshairOn            : in  std_logic;
       Gun2X                      : in  unsigned(7 downto 0);
       Gun2Y_scanlines            : in  unsigned(8 downto 0);   
+      Gun2IRQ10                  : out std_logic;
             
       cdSlow                     : in  std_logic;
             
@@ -456,6 +458,38 @@ begin
       out_ena        => overlay_Gun2_ena
    );
    
+   justifier_sensor1: entity work.justifier_sensor
+   port map
+   (
+      clk            => clkvid,
+      ce             => videoout_out.ce,
+      vsync          => videoout_out.vsync,
+      hblank         => videoout_out.hblank,
+
+      xpos_gun       => Gun1X_screen,
+      ypos_gun       => to_integer(Gun1Y_screen),
+      xpos_screen    => videoout_request_clkvid.xpos,
+      ypos_screen    => to_integer(videoout_request_clkvid.lineDisp),
+
+      out_irq10      => Gun1IRQ10
+   );
+
+   justifier_sensor2: entity work.justifier_sensor
+   port map
+   (
+      clk            => clkvid,
+      ce             => videoout_out.ce,
+      vsync          => videoout_out.vsync,
+      hblank         => videoout_out.hblank,
+
+      xpos_gun       => Gun2X_screen,
+      ypos_gun       => to_integer(Gun2Y_screen),
+      xpos_screen    => videoout_request_clkvid.xpos,
+      ypos_screen    => to_integer(videoout_request_clkvid.lineDisp),
+
+      out_irq10      => Gun2IRQ10
+   );
+
    overlay_ena <= overlay_error_ena or overlay_cd_ena or overlay_fps_ena or debugtextDbg_ena or (overlay_Gun1_ena and Gun1CrosshairOn) or (overlay_Gun2_ena and Gun2CrosshairOn);
    
    overlay_data <= overlay_error_data when (overlay_error_ena = '1') else

--- a/rtl/justifier_sensor.vhd
+++ b/rtl/justifier_sensor.vhd
@@ -1,0 +1,104 @@
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+
+-- todo: This implementation of the Justifier sensor is just using the same
+-- pattern as the crosshair overlay. This will likely need to be adjusted
+-- to get more accurate behavior, once any inaccuracy in the dotclock timers
+-- is worked out.
+-- This implementation also does not yet handle a dedicated "shoot offscreen"
+-- button properly in the same way that other cores do.
+
+entity justifier_sensor is
+   port
+   (
+      clk                  : in  std_logic;
+      ce                   : in  std_logic;
+      vsync                : in  std_logic;
+      hblank               : in  std_logic;
+
+      xpos_gun             : in integer range 0 to 1023;
+      ypos_gun             : in integer range 0 to 1023;
+      xpos_screen          : in integer range 0 to 1023;
+      ypos_screen          : in integer range 0 to 1023;
+
+      out_irq10            : out std_logic := '0'
+   );
+end entity;
+
+architecture arch of justifier_sensor is
+
+   -- receive
+   type tState is
+   (
+      CHECKLINE,
+      CHECKPOS_H,
+      CHECKPOS_V,
+      DRAW,
+      WAITHSYNC
+   );
+   signal state : tState := CHECKLINE;
+
+   signal diff       : integer range -1024 to 1023;
+   signal draw_count : integer range 0 to 7;
+
+begin
+
+   out_irq10  <= '1' when (state = DRAW) else '0';
+
+
+   diff <= ypos_screen - ypos_gun when state = CHECKLINE else
+           xpos_screen - xpos_gun;
+
+   process (clk)
+   begin
+      if rising_edge(clk) then
+
+         case (state) is
+
+            when CHECKLINE =>
+               if (hblank = '0' and diff >= -3 and diff <= 3 and xpos_gun > 0) then
+                  state <= CHECKPOS_V;
+                  if (diff = 0) then
+                     state <= CHECKPOS_H;
+                  end if;
+               end if;
+
+            when CHECKPOS_H =>
+               draw_count <= 6;
+               if (xpos_gun < 4) then
+                  draw_count <= 2 + xpos_gun;
+               end if;
+               if (diff >= -3 and diff <= 3) then
+                  state <= DRAW;
+               end if;
+
+            when CHECKPOS_V =>
+               draw_count <= 0;
+               if (diff = 0) then
+                  state      <= DRAW;
+               end if;
+
+            when DRAW =>
+               if (ce = '1') then
+                  if (draw_count > 0) then
+                     draw_count <= draw_count - 1;
+                  else
+                     state <= WAITHSYNC;
+                  end if;
+               end if;
+
+            when WAITHSYNC =>
+               if (hblank = '1') then
+                  state <= CHECKLINE;
+               end if;
+
+         end case;
+
+         if (vsync = '1') then
+            state <= CHECKLINE;
+         end if;
+
+      end if;
+   end process;
+end architecture;

--- a/rtl/pJoypad.vhd
+++ b/rtl/pJoypad.vhd
@@ -10,6 +10,7 @@ type joypad_t is record
    PadPortMouse  : std_logic;
    PadPortGunCon : std_logic;
    PadPortNeGcon : std_logic;
+   PadPortJustif : std_logic;
    PadPortDS     : std_logic;
 
    WheelMap    : std_logic;

--- a/rtl/psx.qip
+++ b/rtl/psx.qip
@@ -19,6 +19,7 @@ set_global_assignment -name VHDL_FILE [file join $::quartus(qip_path) gpu_overla
 set_global_assignment -name VHDL_FILE [file join $::quartus(qip_path) gpu_videoout_async.vhd ]
 set_global_assignment -name VHDL_FILE [file join $::quartus(qip_path) gpu_videoout_sync.vhd ]
 set_global_assignment -name VHDL_FILE [file join $::quartus(qip_path) gpu_crosshair.vhd ]
+set_global_assignment -name VHDL_FILE [file join $::quartus(qip_path) justifier_sensor.vhd ]
 set_global_assignment -name VHDL_FILE [file join $::quartus(qip_path) gpu_videoout.vhd ]
 set_global_assignment -name VHDL_FILE [file join $::quartus(qip_path) gpu.vhd ]
 set_global_assignment -name VHDL_FILE [file join $::quartus(qip_path) irq.vhd ]

--- a/rtl/psx_mister.vhd
+++ b/rtl/psx_mister.vhd
@@ -135,6 +135,7 @@ entity psx_mister is
       PadPortneGcon1        : in  std_logic;
       PadPortWheel1         : in  std_logic;
       PadPortDS1            : in  std_logic;
+      PadPortJustif1        : in  std_logic;
       PadPortEnable2        : in  std_logic;
       PadPortAnalog2        : in  std_logic;
       PadPortMouse2         : in  std_logic;
@@ -142,6 +143,7 @@ entity psx_mister is
       PadPortneGcon2        : in  std_logic;
       PadPortWheel2         : in  std_logic;
       PadPortDS2            : in  std_logic;
+      PadPortJustif2        : in  std_logic;
       KeyTriangle           : in  std_logic_vector(1 downto 0); 
       KeyCircle             : in  std_logic_vector(1 downto 0); 
       KeyCross              : in  std_logic_vector(1 downto 0); 
@@ -343,6 +345,7 @@ begin
       joypad1.PadPortMouse  => PadPortMouse1,
       joypad1.PadPortGunCon => PadPortGunCon1,
       joypad1.PadPortNeGcon => PadPortNeGcon1,
+      joypad1.PadPortJustif => PadPortJustif1,
       joypad1.WheelMap      => PadPortWheel1,
       joypad1.PadPortDS     => PadPortDS1,
 
@@ -373,6 +376,7 @@ begin
       joypad2.PadPortMouse  => PadPortMouse2,
       joypad2.PadPortGunCon => PadPortGunCon2,
       joypad2.PadPortNeGcon => PadPortNeGcon2,
+      joypad2.PadPortJustif => PadPortJustif2,
       joypad2.WheelMap      => PadPortWheel2,
       joypad2.PadPortDS     => PadPortDS2,
 


### PR DESCRIPTION
This adds initial support for IRQ10-based lightguns like the Konami Justifier.

rtl/justifier_sensor.vhd is currently mostly a copy of rtl/gpu_crosshair.vhd with some names changed. It could probably be simplified or made more accurate to the original Justifier's timing, but this works surprisingly well as a starting point (as long as the game you are playing has a calibration screen, like Area 51 and Lethal Enforcers I and II.)

Without calibration, the location inferred by games is about 80 pixels to the right of the overlay crosshair, and about 8 pixels down from it.