### PR TITLE
add limited multitap emulation

### DIFF
--- a/PSX.sv
+++ b/PSX.sv
@@ -341,7 +341,7 @@ wire reset_or = RESET | buttons[1] | status[0] | bios_download | exe_download | 
 // 0         1         2         3          4         5         6
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-//  X XXXXXXXXX XXXXXXXXXXXX XXXXXX XXXXXXXXXXXXXXXXXXXXXXXXXXXXX XX
+//  X XXXXXXXXXXXXXXXXXXXXXX XXXXXX XXXXXXXXXXXXXXXXXXXXXXXXXXXXX XX
 
 `include "build_id.v"
 parameter CONF_STR = {
@@ -367,10 +367,11 @@ parameter CONF_STR = {
 	"-;",
 	"o78,System Type,Auto,NTSC-U,NTSC-J,PAL;",
 	"-;",
-	"oDG,Pad1,Dualshock,Off,Digital,Analog,GunCon,NeGcon,Wheel-NegCon,Wheel-Analog,Mouse,Justifier,SNAC-port1,Analog Joystick;",
-	"oHK,Pad2,Dualshock,Off,Digital,Analog,GunCon,NeGcon,Wheel-NegCon,Wheel-Analog,Mouse,Justifier,SNAC-port2,Analog Joystick;",
-	"h2O9,Show Crosshair,Off,On;",
-	"h4OV,DS Mode,L3+R3+Up/Dn | Click,L1+L2+R1+R2+Up/Dn;",
+	"D8oDG,Pad1,Dualshock,Off,Digital,Analog,GunCon,NeGcon,Wheel-NegCon,Wheel-Analog,Mouse,Justifier,SNAC-port1,Analog Joystick;",
+	"D8oHK,Pad2,Dualshock,Off,Digital,Analog,GunCon,NeGcon,Wheel-NegCon,Wheel-Analog,Mouse,Justifier,SNAC-port2,Analog Joystick;",
+	"D8h2O9,Show Crosshair,Off,On;",
+	"D8h4OV,DS Mode,L3+R3+Up/Dn | Click,L1+L2+R1+R2+Up/Dn;",
+	"OC,Multitap,Off,Port1: 4 x Digital;",
 	"-;",
 	"OS,FPS Overlay,Off,On;",
 	"OT,Error Overlay,On,Off;",
@@ -453,7 +454,7 @@ parameter CONF_STR = {
 reg dbg_enabled = 0;
 wire  [1:0] buttons;
 wire [63:0] status;
-wire [15:0] status_menumask = {biosMod, ~status[58], status[55], (PadPortDS1 | PadPortDS2), dbg_enabled, (PadPortGunCon1 | PadPortGunCon2 | PadPortJustif1 | PadPortJustif2), SDRAM2_EN, 1'b0};
+wire [15:0] status_menumask = {multitap, biosMod, ~status[58], status[55], (PadPortDS1 | PadPortDS2), dbg_enabled, (PadPortGunCon1 | PadPortGunCon2 | PadPortJustif1 | PadPortJustif2), SDRAM2_EN, 1'b0};
 wire        forced_scandoubler;
 reg  [31:0] sd_lba0 = 0;
 reg  [31:0] sd_lba1;
@@ -480,6 +481,8 @@ reg         ioctl_wait = 0;
 wire [17:0] joy;
 wire [17:0] joy_unmod;
 wire [17:0] joy2;
+wire [17:0] joy3;
+wire [17:0] joy4;
 
 wire [10:0] ps2_key;
 
@@ -490,11 +493,17 @@ wire [15:0] joystick_analog_l0;
 wire [15:0] joystick_analog_r0;
 wire [15:0] joystick_analog_l1;
 wire [15:0] joystick_analog_r1;
+wire [15:0] joystick_analog_l2;
+wire [15:0] joystick_analog_r2;
+wire [15:0] joystick_analog_l3;
+wire [15:0] joystick_analog_r3;
 
 wire [24:0] mouse;
 
 wire [15:0] joystick1_rumble;
 wire [15:0] joystick2_rumble;
+wire [15:0] joystick3_rumble;
+wire [15:0] joystick4_rumble;
 wire [32:0] RTC_time;
 
 wire [63:0] status_in = {status[63:39],ss_slot,status[36:0]};
@@ -513,6 +522,8 @@ hps_io #(.CONF_STR(CONF_STR), .WIDE(1), .VDNUM(4), .BLKSZ(3)) hps_io
 
 	.joystick_0(joy_unmod),
 	.joystick_1(joy2),
+	.joystick_2(joy3),
+	.joystick_3(joy4),
 	.ps2_key(ps2_key),
 
 	.status(status),
@@ -780,6 +791,8 @@ wire PadPortJustif2 = (status[52:49] == 4'b1001);
 wire snacPort2      = (status[52:49] == 4'b1010);
 wire PadPortStick2  = (status[52:49] == 4'b1011);
 
+wire multitap       = status[12];
+
 wire [1:0] padMode;
 reg  [1:0] padMode_1;
 
@@ -1024,22 +1037,22 @@ psx
    .PadPortDS2     (PadPortDS2),
    .PadPortJustif2 (PadPortJustif2),
    .PadPortStick2  (PadPortStick2),
-   .KeyTriangle({joy2[4], joy[4] }),    
-   .KeyCircle  ({joy2[5] ,joy[5] }),       
-   .KeyCross   ({joy2[6] ,joy[6] }),       
-   .KeySquare  ({joy2[7] ,joy[7] }),       
-   .KeySelect  ({joy2[8] ,joy[8] }),       
-   .KeyStart   ({joy2[9] ,joy[9] }),        
-   .KeyRight   ({joy2[0] ,joy[0] }),
-   .KeyLeft    ({joy2[1] ,joy[1] }),
-   .KeyUp      ({joy2[3] ,joy[3] }),
-   .KeyDown    ({joy2[2] ,joy[2] }),      
-   .KeyR1      ({joy2[11],joy[11]}),          
-   .KeyR2      ({joy2[13],joy[13]}),          
-   .KeyR3      ({joy2[15],joy[15]}),          
-   .KeyL1      ({joy2[10],joy[10]}),          
-   .KeyL2      ({joy2[12],joy[12]}),          
-   .KeyL3      ({joy2[14],joy[14]}),          
+   .KeyTriangle({joy4[4], joy3[4], joy2[4], joy[4] }),
+   .KeyCircle  ({joy4[5] ,joy3[5] ,joy2[5] ,joy[5] }),
+   .KeyCross   ({joy4[6] ,joy3[6] ,joy2[6] ,joy[6] }),
+   .KeySquare  ({joy4[7] ,joy3[7] ,joy2[7] ,joy[7] }),
+   .KeySelect  ({joy4[8] ,joy3[8] ,joy2[8] ,joy[8] }),
+   .KeyStart   ({joy4[9] ,joy3[9] ,joy2[9] ,joy[9] }),
+   .KeyRight   ({joy4[0] ,joy3[0] ,joy2[0] ,joy[0] }),
+   .KeyLeft    ({joy4[1] ,joy3[1] ,joy2[1] ,joy[1] }),
+   .KeyUp      ({joy4[3] ,joy3[3] ,joy2[3] ,joy[3] }),
+   .KeyDown    ({joy4[2] ,joy3[2] ,joy2[2] ,joy[2] }),
+   .KeyR1      ({joy4[11],joy3[11],joy2[11],joy[11]}),
+   .KeyR2      ({joy4[13],joy3[13],joy2[13],joy[13]}),
+   .KeyR3      ({joy4[15],joy3[15],joy2[15],joy[15]}),
+   .KeyL1      ({joy4[10],joy3[10],joy2[10],joy[10]}),
+   .KeyL2      ({joy4[12],joy3[12],joy2[12],joy[12]}),
+   .KeyL3      ({joy4[14],joy3[14],joy2[14],joy[14]}),
    .Analog1XP1(joystick_analog_l0[7:0]),       
    .Analog1YP1(joystick_analog_l0[15:8]),       
    .Analog2XP1(joystick_analog_r0[7:0]),           
@@ -1048,14 +1061,25 @@ psx
    .Analog1YP2(joystick_analog_l1[15:8]),       
    .Analog2XP2(joystick_analog_r1[7:0]),           
    .Analog2YP2(joystick_analog_r1[15:8]),           
+   .Analog1XP3(joystick_analog_l2[7:0]),
+   .Analog1YP3(joystick_analog_l2[15:8]),
+   .Analog2XP3(joystick_analog_r2[7:0]),
+   .Analog2YP3(joystick_analog_r2[15:8]),
+   .Analog1XP4(joystick_analog_l3[7:0]),
+   .Analog1YP4(joystick_analog_l3[15:8]),
+   .Analog2XP4(joystick_analog_r3[7:0]),
+   .Analog2YP4(joystick_analog_r3[15:8]),
    .RumbleDataP1(joystick1_rumble),
    .RumbleDataP2(joystick2_rumble),
+   .RumbleDataP3(joystick3_rumble),
+   .RumbleDataP4(joystick4_rumble),
    .padMode(padMode),
    .MouseEvent(mouse[24]),
    .MouseLeft(mouse[0]),
    .MouseRight(mouse[1]),
    .MouseX({mouse[4],mouse[15:8]}),
    .MouseY({mouse[5],mouse[23:16]}),
+   .multitap(multitap),
    //snac
    .snacPort1(snacPort1),
    .snacPort2(snacPort2),

--- a/rtl/joypad.vhd
+++ b/rtl/joypad.vhd
@@ -19,8 +19,13 @@ entity joypad is
       DSAltSwitchMode      : in  std_logic;
       joypad1              : in  joypad_t;
       joypad2              : in  joypad_t;
+      joypad3              : in  joypad_t;
+      joypad4              : in  joypad_t;
+      multitap             : in  std_logic;
       joypad1_rumble       : out std_logic_vector(15 downto 0) := (others => '0');
       joypad2_rumble       : out std_logic_vector(15 downto 0) := (others => '0');
+      joypad3_rumble       : out std_logic_vector(15 downto 0) := (others => '0');
+      joypad4_rumble       : out std_logic_vector(15 downto 0) := (others => '0');
       padMode              : out std_logic_vector(1 downto 0);
 
       memcard1_available   : in  std_logic;
@@ -152,7 +157,6 @@ architecture arch of joypad is
    signal receiveValidMem1    : std_logic;
    signal receiveValidMem2    : std_logic;
 
-   signal joypad_selected     : joypad_t;
    signal rumble_selected     : std_logic_vector(15 downto 0);
    signal rumble_previous     : std_logic_vector(15 downto 0);
    signal GunX                : unsigned(7 downto 0);
@@ -389,7 +393,6 @@ begin
                  '1' when (JOY_CTRL(13) = '1' and JOY_CTRL(1 downto 0) = "11" and snacPort2 = '0') else 
                  '0';
 
-   joypad_selected <= joypad2 when selectedPort2 else joypad1;
    GunX            <= Gun2X when selectedPort2 else Gun1X;
    GunY_scanlines  <= Gun2Y_scanlines when selectedPort2 else Gun1Y_scanlines;
    GunAimOffscreen <= Gun2AimOffscreen when selectedPort2 else Gun1AimOffscreen;
@@ -403,9 +406,13 @@ begin
       reset                => reset,    
        
       DSAltSwitchMode      => DSAltSwitchMode,
-      joypad               => joypad_selected,
+      joypad1              => joypad1,
+      joypad2              => joypad2,
+      joypad3              => joypad3,
+      joypad4              => joypad4,
       rumble               => rumble_selected,
       padMode              => padMode,
+      isMultitap           => multitap,
       portNr               => portNr,
       isPal                => isPal,
 

--- a/rtl/psx_mister.vhd
+++ b/rtl/psx_mister.vhd
@@ -152,22 +152,22 @@ entity psx_mister is
       PadPortDS2            : in  std_logic;
       PadPortJustif2        : in  std_logic;
       PadPortStick2         : in  std_logic;
-      KeyTriangle           : in  std_logic_vector(1 downto 0); 
-      KeyCircle             : in  std_logic_vector(1 downto 0); 
-      KeyCross              : in  std_logic_vector(1 downto 0); 
-      KeySquare             : in  std_logic_vector(1 downto 0);
-      KeySelect             : in  std_logic_vector(1 downto 0);
-      KeyStart              : in  std_logic_vector(1 downto 0);
-      KeyRight              : in  std_logic_vector(1 downto 0);
-      KeyLeft               : in  std_logic_vector(1 downto 0);
-      KeyUp                 : in  std_logic_vector(1 downto 0);
-      KeyDown               : in  std_logic_vector(1 downto 0);
-      KeyR1                 : in  std_logic_vector(1 downto 0);
-      KeyR2                 : in  std_logic_vector(1 downto 0);
-      KeyR3                 : in  std_logic_vector(1 downto 0);
-      KeyL1                 : in  std_logic_vector(1 downto 0);
-      KeyL2                 : in  std_logic_vector(1 downto 0);
-      KeyL3                 : in  std_logic_vector(1 downto 0);
+      KeyTriangle           : in  std_logic_vector(3 downto 0);
+      KeyCircle             : in  std_logic_vector(3 downto 0);
+      KeyCross              : in  std_logic_vector(3 downto 0);
+      KeySquare             : in  std_logic_vector(3 downto 0);
+      KeySelect             : in  std_logic_vector(3 downto 0);
+      KeyStart              : in  std_logic_vector(3 downto 0);
+      KeyRight              : in  std_logic_vector(3 downto 0);
+      KeyLeft               : in  std_logic_vector(3 downto 0);
+      KeyUp                 : in  std_logic_vector(3 downto 0);
+      KeyDown               : in  std_logic_vector(3 downto 0);
+      KeyR1                 : in  std_logic_vector(3 downto 0);
+      KeyR2                 : in  std_logic_vector(3 downto 0);
+      KeyR3                 : in  std_logic_vector(3 downto 0);
+      KeyL1                 : in  std_logic_vector(3 downto 0);
+      KeyL2                 : in  std_logic_vector(3 downto 0);
+      KeyL3                 : in  std_logic_vector(3 downto 0);
       Analog1XP1            : in  signed(7 downto 0);
       Analog1YP1            : in  signed(7 downto 0);
       Analog2XP1            : in  signed(7 downto 0);
@@ -176,6 +176,15 @@ entity psx_mister is
       Analog1YP2            : in  signed(7 downto 0);
       Analog2XP2            : in  signed(7 downto 0);
       Analog2YP2            : in  signed(7 downto 0);                  
+      Analog1XP3            : in  signed(7 downto 0);
+      Analog1YP3            : in  signed(7 downto 0);
+      Analog2XP3            : in  signed(7 downto 0);
+      Analog2YP3            : in  signed(7 downto 0);
+      Analog1XP4            : in  signed(7 downto 0);
+      Analog1YP4            : in  signed(7 downto 0);
+      Analog2XP4            : in  signed(7 downto 0);
+      Analog2YP4            : in  signed(7 downto 0);
+      multitap              : in  std_logic;
       -- mouse
       MouseEvent            : in  std_logic;
       MouseLeft             : in  std_logic;
@@ -184,6 +193,8 @@ entity psx_mister is
       MouseY                : in  signed(8 downto 0);
       RumbleDataP1          : out std_logic_vector(15 downto 0);
       RumbleDataP2          : out std_logic_vector(15 downto 0);
+      RumbleDataP3          : out std_logic_vector(15 downto 0);
+      RumbleDataP4          : out std_logic_vector(15 downto 0);
       padMode               : out std_logic_vector(1 downto 0);
       -- snac
       snacPort1             : in  std_logic;
@@ -432,7 +443,71 @@ begin
       joypad2.Analog2X      => Analog2XP2,
       joypad2.Analog2Y      => Analog2YP2,
       joypad2_rumble        => RumbleDataP2,
-      
+
+      joypad3.PadPortEnable => '1',
+      joypad3.PadPortAnalog => '0',
+      joypad3.PadPortMouse  => '0',
+      joypad3.PadPortGunCon => '0',
+      joypad3.PadPortNeGcon => '0',
+      joypad3.PadPortJustif => '0',
+      joypad3.WheelMap      => '0',
+      joypad3.PadPortDS     => '0',
+
+      joypad3.KeyTriangle   => KeyTriangle(2),
+      joypad3.KeyCircle     => KeyCircle(2),
+      joypad3.KeyCross      => KeyCross(2),
+      joypad3.KeySquare     => KeySquare(2),
+      joypad3.KeySelect     => KeySelect(2),
+      joypad3.KeyStart      => KeyStart(2),
+      joypad3.KeyRight      => KeyRight(2),
+      joypad3.KeyLeft       => KeyLeft(2),
+      joypad3.KeyUp         => KeyUp(2),
+      joypad3.KeyDown       => KeyDown(2),
+      joypad3.KeyR1         => KeyR1(2),
+      joypad3.KeyR2         => KeyR2(2),
+      joypad3.KeyR3         => KeyR3(2),
+      joypad3.KeyL1         => KeyL1(2),
+      joypad3.KeyL2         => KeyL2(2),
+      joypad3.KeyL3         => KeyL3(2),
+      joypad3.Analog1X      => Analog1XP3,
+      joypad3.Analog1Y      => Analog1YP3,
+      joypad3.Analog2X      => Analog2XP3,
+      joypad3.Analog2Y      => Analog2YP3,
+      joypad3_rumble        => RumbleDataP3,
+
+      joypad4.PadPortEnable => '1',
+      joypad4.PadPortAnalog => '0',
+      joypad4.PadPortMouse  => '0',
+      joypad4.PadPortGunCon => '0',
+      joypad4.PadPortNeGcon => '0',
+      joypad4.PadPortJustif => '0',
+      joypad4.WheelMap      => '0',
+      joypad4.PadPortDS     => '0',
+
+      joypad4.KeyTriangle   => KeyTriangle(3),
+      joypad4.KeyCircle     => KeyCircle(3),
+      joypad4.KeyCross      => KeyCross(3),
+      joypad4.KeySquare     => KeySquare(3),
+      joypad4.KeySelect     => KeySelect(3),
+      joypad4.KeyStart      => KeyStart(3),
+      joypad4.KeyRight      => KeyRight(3),
+      joypad4.KeyLeft       => KeyLeft(3),
+      joypad4.KeyUp         => KeyUp(3),
+      joypad4.KeyDown       => KeyDown(3),
+      joypad4.KeyR1         => KeyR1(3),
+      joypad4.KeyR2         => KeyR2(3),
+      joypad4.KeyR3         => KeyR3(3),
+      joypad4.KeyL1         => KeyL1(3),
+      joypad4.KeyL2         => KeyL2(3),
+      joypad4.KeyL3         => KeyL3(3),
+      joypad4.Analog1X      => Analog1XP4,
+      joypad4.Analog1Y      => Analog1YP4,
+      joypad4.Analog2X      => Analog2XP4,
+      joypad4.Analog2Y      => Analog2YP4,
+      joypad4_rumble        => RumbleDataP4,
+
+      multitap              => multitap,
+
       padMode               => padMode,
 
       MouseEvent            => MouseEvent,

--- a/rtl/psx_top.vhd
+++ b/rtl/psx_top.vhd
@@ -140,8 +140,13 @@ entity psx_top is
       DSAltSwitchMode       : in  std_logic;
       joypad1               : in  joypad_t;
       joypad2               : in  joypad_t;
+      joypad3               : in  joypad_t;
+      joypad4               : in  joypad_t;
+      multitap              : in  std_logic;
       joypad1_rumble        : out std_logic_vector(15 downto 0);
       joypad2_rumble        : out std_logic_vector(15 downto 0);
+      joypad3_rumble        : out std_logic_vector(15 downto 0);
+      joypad4_rumble        : out std_logic_vector(15 downto 0);
       padMode               : out std_logic_vector(1 downto 0);
 
       MouseEvent            : in  std_logic;
@@ -937,8 +942,13 @@ begin
       DSAltSwitchMode      => DSAltSwitchMode,
       joypad1              => joypad1,
       joypad2              => joypad2,
+      joypad3              => joypad3,
+      joypad4              => joypad4,
+      multitap             => multitap,
       joypad1_rumble       => joypad1_rumble,
       joypad2_rumble       => joypad2_rumble,
+      joypad3_rumble       => joypad3_rumble,
+      joypad4_rumble       => joypad4_rumble,
       padMode              => padMode,
 
       memcard1_available   => memcard1_available,


### PR DESCRIPTION
Currently only emulates a multitap on port1, with 4 digital controllers
connected.