### PR TITLE
- CD: Implement backward-seek behavior (skip only when ≥2 sectors behind) - fixes Dave Mirra / Trasher

### DIFF
--- a/rtl/cd_top.vhd
+++ b/rtl/cd_top.vhd
@@ -1915,6 +1915,9 @@ begin
                         ackDriveEnd  <= '1';
                      else
                         skipreading := '0';
+						if (setLocActive = '1' and (currentLBA - seekLBA) >= 2) then
+						   skipreading := '1';
+						end if;
                         if (isAudio = '1') then
                            if (currentTrackBCD = x"00") then -- auto find track number from subheader
                               currentTrackBCD <= nextSubdata(1);


### PR DESCRIPTION
- Fix for Dave Mirra / Trasher games https://github.com/MiSTer-devel/PSX_MiSTer/issues/169