### PR TITLE
CD: improve seek timing, physical positioning (SPT table) and sector read timing  (fixes Max Power Racing, PaRappa the Rapper and MiruMiru)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ One card can be mounted for each controller slot. Cards are in raw .mcd format. 
 
 You need to save them either manually in the OSD or turn on autosave. Saving or loading a card will pause the core for a short time.
 
+## CUE+BIN and CHD files
+
+For proper operation, CUE/BIN and CHD game files should be placed in separate folders, with one folder per game. This allows the core to automatically create a dedicated virtual memory card for each game, preventing save data from being shared between different titles.
+
+Additionally, when a new game is selected, the core automatically resets itself, ensuring the game starts correctly without requiring a manual restart.
+
 ## Multiple Disc Games
 
 To swap discs while the game is running, all disc files for the game must be placed in the same folder. When a disc change is required, the core will automatically simulate opening and closing the disc lid. Example folder structure of a multi-disc game:

--- a/rtl/cd_top.vhd
+++ b/rtl/cd_top.vhd
@@ -233,7 +233,7 @@ architecture arch of cd_top is
    signal seekLBA                   : integer range 0 to 524287; 
    signal playLBA                   : integer range 0 to 524287; 
    signal diffLBA                   : integer range 0 to 524287; 
-   signal seekTimeMul               : integer range 0 to 274; 
+   signal seekTimeMul               : integer range 0 to 137; 
    signal currentTrackBCD           : std_logic_vector(7 downto 0);
    signal nextTrack                 : std_logic_vector(7 downto 0);
    
@@ -2084,11 +2084,7 @@ begin
                else
                   -- extreme sled seek only when starting from inner position after Stop
                   if (currentLBA = 0) then
-                     if (modeReg(7) = '1') then
-                        seekTimeMul <= 274;
-                     else
-                        seekTimeMul <= 137;
-                     end if;
+                     seekTimeMul <= 137;
                   else
                      seekTimeMul <= 31 + diffLBA / 8192;
                   end if;

--- a/rtl/cd_top.vhd
+++ b/rtl/cd_top.vhd
@@ -1100,10 +1100,18 @@ begin
                            workCommand <= nextCmd;
                            cmdResetXa  <= '1';
                      
-                           -- cancel read/play after seek
-                           stop_afterseek <= '1';
-						   -- abort active seek operation
-						   drive_stop     <= '1';
+                           if (readAfterSeek = '1') then
+                              -- cancel pending read after seek - Parasite Eve II
+                              stop_afterseek <= '1';
+                              -- abort active seek operation - Vigilante 8
+                              drive_stop <= '1';
+                           elsif (playAfterSeek = '1') then
+                              -- keep pending play-after-seek alive for CDDA startup
+                              null;
+                           else
+                              -- abort pure seek operation
+                              drive_stop <= '1';
+                           end if;
                      
                         -- CASE 2: PAUSE during READ/PLAY but first sector NOT delivered yet
                         -- (Duke Nukem / MiruMiru)

--- a/rtl/cd_top.vhd
+++ b/rtl/cd_top.vhd
@@ -1108,9 +1108,6 @@ begin
                            elsif (playAfterSeek = '1') then
                               -- keep pending play-after-seek alive for CDDA startup
                               null;
-                           else
-                              -- abort pure seek operation
-                              drive_stop <= '1';
                            end if;
                      
                         -- CASE 2: PAUSE during READ/PLAY but first sector NOT delivered yet

--- a/rtl/cd_top.vhd
+++ b/rtl/cd_top.vhd
@@ -280,6 +280,7 @@ architecture arch of cd_top is
    signal phy_base                 : integer range 0 to 524287;
    signal phy_oldOffset            : integer range 0 to 31;
    signal phy_newOffset            : integer range 0 to 31;
+   signal phy_spt                  : integer range 8 to 22 := 8;
    
    -- sector fetch
    type tsectorFetch is
@@ -1733,6 +1734,8 @@ begin
    process(clk1x)
       variable skipreading     : std_logic;
       variable physicalLBANew  : integer range 0 to 524287;
+      variable phy_mm_v        : integer range 0 to 116;
+      variable phy_spt_v       : integer range 8 to 22;															
    begin
       if (rising_edge(clk1x)) then
 
@@ -2268,15 +2271,51 @@ begin
                      physicalUpdateState <= PHYSICALUPDATE_START;
                   end if;
             
-               when PHYSICALUPDATE_START =>
-                  physicalUpdateState <= PHYSICALUPDATE_CHECK;
-                  -- todo: if (!lastSectorHeaderValid) -> different base position and different sectors per track?
-                  -- todo: fixed 32 sectorPerTrack, should be 7.0f + 2.811844405f * std::log((float)(currentLBA / 4500) + 1);
-                  if (currentlba < 32) then
-                     phy_base <= currentlba;
-                  else
-                     phy_base <= currentlba - 31;
-                  end if;
+            when PHYSICALUPDATE_START =>
+               physicalUpdateState <= PHYSICALUPDATE_CHECK;
+
+               -- rama PSX mech SPT table
+               phy_mm_v := currentLBA / FRAMES_PER_MINUTE;
+
+               if (phy_mm_v = 0) then
+                  phy_spt_v := 8;
+               elsif (phy_mm_v <= 4) then
+                  phy_spt_v := 9;
+               elsif (phy_mm_v <= 7) then
+                  phy_spt_v := 10;
+               elsif (phy_mm_v <= 11) then
+                  phy_spt_v := 11;
+               elsif (phy_mm_v <= 16) then
+                  phy_spt_v := 12;
+               elsif (phy_mm_v <= 23) then
+                  phy_spt_v := 13;
+               elsif (phy_mm_v <= 27) then
+                  phy_spt_v := 14;
+               elsif (phy_mm_v <= 32) then
+                  phy_spt_v := 15;
+               elsif (phy_mm_v <= 39) then
+                  phy_spt_v := 16;
+               elsif (phy_mm_v <= 44) then
+                  phy_spt_v := 17;
+               elsif (phy_mm_v <= 52) then
+                  phy_spt_v := 18;
+               elsif (phy_mm_v <= 60) then
+                  phy_spt_v := 19;
+               elsif (phy_mm_v <= 67) then
+                  phy_spt_v := 20;
+               elsif (phy_mm_v <= 74) then
+                  phy_spt_v := 21;
+               else
+                  phy_spt_v := 22;
+               end if;
+
+               phy_spt <= phy_spt_v;
+
+               if (currentLBA < phy_spt_v) then
+                  phy_base <= currentLBA;
+               else
+                  phy_base <= currentLBA - (phy_spt_v - 1);
+               end if;
                   
                when PHYSICALUPDATE_CHECK =>
                   physicalUpdateState <= PHYSICALUPDATE_CALC1;
@@ -2290,7 +2329,7 @@ begin
                   
                when PHYSICALUPDATE_CALC2 =>  
                   physicalUpdateState <= PHYSICALUPDATE_CALCDONE;
-                  phy_newOffset <= (phy_oldOffset + 1) mod 32;
+                  phy_newOffset <= (phy_oldOffset + 1) mod phy_spt;
             
                when PHYSICALUPDATE_CALCDONE =>
                   physicalLBANew := phy_base + phy_newOffset;

--- a/rtl/cd_top.vhd
+++ b/rtl/cd_top.vhd
@@ -233,7 +233,7 @@ architecture arch of cd_top is
    signal seekLBA                   : integer range 0 to 524287; 
    signal playLBA                   : integer range 0 to 524287; 
    signal diffLBA                   : integer range 0 to 524287; 
-   signal seekTimeMul               : integer range 0 to 127; 
+   signal seekTimeMul               : integer range 0 to 274; 
    signal currentTrackBCD           : std_logic_vector(7 downto 0);
    signal nextTrack                 : std_logic_vector(7 downto 0);
    
@@ -2078,10 +2078,22 @@ begin
                   seekTimeMul <= 5 + diffLBA / 8; -- 5 .. 14
                elsif (diffLBA < 4500) then
                   seekTimeMul <= 14 + diffLBA / 256; -- 14 .. 31
+            
+               elsif (diffLBA < 250000) then
+                  seekTimeMul <= 31 + diffLBA / 8192; -- 31 .. 73            
                else
-                  seekTimeMul <= 31 + diffLBA / 8192; -- 31 .. 73
+                  -- extreme sled seek only when starting from inner position after Stop
+                  if (currentLBA = 0) then
+                     if (modeReg(7) = '1') then
+                        seekTimeMul <= 274;
+                     else
+                        seekTimeMul <= 137;
+                     end if;
+                  else
+                     seekTimeMul <= 31 + diffLBA / 8192;
+                  end if;
                end if;
-                  
+			   
             end if;
             
             if (addSeekTime = '1') then
@@ -2212,6 +2224,7 @@ begin
                driveBusy                  <= '0';
                internalStatus(7 downto 5) <= "000"; -- ClearActiveBits
                internalStatus(1)          <= '0';   --motor off
+			   currentLBA                 <= 0;
             end if;
             
             if (drive_stop = '1') then

--- a/rtl/cd_top.vhd
+++ b/rtl/cd_top.vhd
@@ -2893,17 +2893,30 @@ begin
             
                when COPY_IDLE =>
                   if (copyData = '1' and ce = '1') then
-                     copyState         <= COPY_FIRST;
+               
+                     copySectorPointer <= readSectorPointer;
                      copyCount         <= 0;
                      copyReadAddr      <= 0;
                      copyByteCnt       <= 0;
-                     copySectorPointer <= readSectorPointer;
-                     sectorBufferSizes(to_integer(readSectorPointer)) <= 0;
-                     if (sectorBufferSizes(to_integer(readSectorPointer)) = 0) then
-                        copySize <= RAW_SECTOR_OUTPUT_SIZE / 4;
-                     else
+               
+                     if (sectorBufferSizes(to_integer(readSectorPointer)) /= 0) then
                         copySize <= sectorBufferSizes(to_integer(readSectorPointer));
+                        sectorBufferSizes(to_integer(readSectorPointer)) <= 0;
+                        copyState <= COPY_FIRST;
+               
+                     elsif (
+                        sectorBufferSizes = (others => 0) and
+                        modeReg(5) = '0' and
+                        driveState = DRIVE_READING
+                     ) then
+                        -- MiruMiru: data read, drive really reading, empty buffer -> wait
+                        null;
+               
+                     else
+                        copySize  <= RAW_SECTOR_OUTPUT_SIZE / 4;
+                        copyState <= COPY_FIRST;
                      end if;
+               
                   end if;
                
                when COPY_FIRST =>

--- a/rtl/cd_top.vhd
+++ b/rtl/cd_top.vhd
@@ -264,6 +264,7 @@ architecture arch of cd_top is
    signal clearSectorBuffers        : std_logic := '0';  
    signal writeSectorPointer        : unsigned(2 downto 0) := (others => '0');
    signal readSectorPointer         : unsigned(2 downto 0) := (others => '0');
+   signal firstSectorPending        : std_logic := '0';
    
    type tphysicalUpdateState is
    (
@@ -589,8 +590,12 @@ begin
                            
                            when x"3" =>
                               if (bus_dataWrite(7) = '1') then
-                                 if (FifoData_Empty = '1') then -- don't do anything when data still inside?
-                                    copyData <= '1';
+                                 if (FifoData_Empty = '1') then
+                           
+                                    if (firstSectorPending = '0') then
+                                       copyData <= '1';
+                                    end if;
+                           
                                  end if;
                               else
                                  FifoData_reset <= '1';
@@ -2819,6 +2824,7 @@ begin
                      --error <= '1';
                   end if;
                   sectorBufferSizes(to_integer(writeSectorPointer)) <= procSize;
+				  firstSectorPending <= '0';
                
                when SPROC_DATA =>
                   procCount    <= procCount + 1;
@@ -2889,30 +2895,17 @@ begin
             
                when COPY_IDLE =>
                   if (copyData = '1' and ce = '1') then
-               
-                     copySectorPointer <= readSectorPointer;
+                     copyState         <= COPY_FIRST;
                      copyCount         <= 0;
                      copyReadAddr      <= 0;
                      copyByteCnt       <= 0;
-               
-                     if (sectorBufferSizes(to_integer(readSectorPointer)) /= 0) then
-                        copySize <= sectorBufferSizes(to_integer(readSectorPointer));
-                        sectorBufferSizes(to_integer(readSectorPointer)) <= 0;
-                        copyState <= COPY_FIRST;
-               
-                     elsif (
-                        sectorBufferSizes = (others => 0) and
-                        modeReg(5) = '0' and
-                        driveState = DRIVE_READING
-                     ) then
-                        -- MiruMiru: data read, drive really reading, empty buffer -> wait
-                        null;
-               
+                     copySectorPointer <= readSectorPointer;
+                     sectorBufferSizes(to_integer(readSectorPointer)) <= 0;
+                     if (sectorBufferSizes(to_integer(readSectorPointer)) = 0) then
+                        copySize <= RAW_SECTOR_OUTPUT_SIZE / 4;
                      else
-                        copySize  <= RAW_SECTOR_OUTPUT_SIZE / 4;
-                        copyState <= COPY_FIRST;
+                        copySize <= sectorBufferSizes(to_integer(readSectorPointer));
                      end if;
-               
                   end if;
                
                when COPY_FIRST =>
@@ -2950,13 +2943,17 @@ begin
             end case;
             
             -- if data fifo is reset while copy is still ongoing, stop copy immidiatly so fifo stays empty
-            if (FifoData_reset = '1' and copyState /= COPY_IDLE) then
-               copyState   <= COPY_IDLE;
-               FifoData_Wr <= '0';
+            if (FifoData_reset = '1') then            
+               firstSectorPending <= '0';            
+               if (copyState /= COPY_IDLE) then
+                  copyState   <= COPY_IDLE;
+                  FifoData_Wr <= '0';
+               end if;            
             end if;
             
             if (clearSectorBuffers = '1') then
                sectorBufferSizes <= (others => 0);
+			   firstSectorPending <= '1';
             end if;
 
          end if;


### PR DESCRIPTION
- Fix pause handling during seek, restoring correct music playback
  in Max Power Racing. Issue #356

- Use real PSX sectors-per-track values (rama measurements) instead
  of fixed 32-sector geometry for the physical position model.

  Improves physicalLBA and GetLocP accuracy.

- Add long sled seek timing for very large seeks starting from
  currentLBA = 0, matching the game's expected long forward seek behavior after Stop.

  Fixes FMV/XA desync and white screen issues in Parappa the Rapper
  (JP). Issue #142.

- CD: fix sector buffer read timing edge case (MiruMiru demo)

  The original MiruMiru fix relied on additional logic in COPY_IDLE to
  delay data transfers when no processed sector was available. 

  This change takes a different approach and leaves the COPY state machine
  unchanged. Instead of modifying COPY_IDLE behavior, BFRD requests are
  temporarily blocked only while waiting for the first processed sector to
  become available.

  Once the first sector has been processed, normal behavior is restored.
  Pending state is also cleared when transfers are aborted, preventing
  stale state from affecting subsequent reads.

  This isolates the MiruMiru specific timing issue without altering the
  existing copy path or RAW sector transfer behavior. Issue #319
  
- Update README