### PR TITLE
SNAC: Fix MCtransfer not being reset between transfers (fixes screen tearing)

### DIFF
--- a/PSX.sv
+++ b/PSX.sv
@@ -1836,8 +1836,9 @@ begin
 	oldselectedPort2 <= selectedPort2Snac;
 
 	if ((~oldselectedPort1 && selectedPort1Snac) || (~oldselectedPort2 && selectedPort2Snac)) begin
-		byteCnt   <= 9'd0;
-		bytesLeft <= 9'd0;
+		byteCnt    <= 9'd0;
+		bytesLeft  <= 9'd0;
+		MCtransfer <= 1'b0;
 	end
 
 	if (beginTransferSnac) begin


### PR DESCRIPTION
MCtransfer only ever gets assigned at byteCnt==2, so bytes 0 and 1 of a new transfer still see whatever it was set to last time. Once a memory card has been accessed it stays high, and the next pad poll ends up using the long card ack timer instead of the normal one. With nothing acking on the port that stalls things every frame, which shows up as tearing.

Clearing it on session start fixes that - it only goes high again when a card is actually detected. byteCnt and bytesLeft were already being reset here, MCtransfer was just missed.